### PR TITLE
Endre Norg2 url

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -64,10 +64,6 @@ spec:
       value: api://dev-gcp.nom.skjermede-personer-pip/.default
     - name: SKJERMET_PERSON_URL
       value: http://skjermede-personer-pip.nom.svc.cluster.local
-    - name: POAO_GCP_PROXY_SCOPE
-      value: api://dev-fss.pto.poao-gcp-proxy/.default
-    - name: POAO_GCP_PROXY_URL
-      value: https://poao-gcp-proxy.dev-fss-pub.nais.io
     - name: AXSYS_URL
       value: https://axsys.dev-fss-pub.nais.io
     - name: AXSYS_SCOPE
@@ -84,8 +80,8 @@ spec:
       value: api://dev-fss.pdl.pdl-api/.default
     - name: PDL_URL
       value: https://pdl-api.dev-fss-pub.nais.io
-    - name: RUNTIME_LOCATION
-      value: GCP
+    - name: NORG_URL
+      value: https://norg2.dev-fss-pub.nais.io
     - name: AD_GRUPPE_ID_FORTROLIG_ADRESSE
       value: ea930b6b-9397-44d9-b9e6-f4cf527a632a
     - name: AD_GRUPPE_ID_STRENGT_FORTROLIG_ADRESSE

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -64,10 +64,6 @@ spec:
       value: api://prod-gcp.nom.skjermede-personer-pip/.default
     - name: SKJERMET_PERSON_URL
       value: http://skjermede-personer-pip.nom.svc.cluster.local
-    - name: POAO_GCP_PROXY_SCOPE
-      value: api://prod-fss.pto.poao-gcp-proxy/.default
-    - name: POAO_GCP_PROXY_URL
-      value: https://poao-gcp-proxy.prod-fss-pub.nais.io
     - name: AXSYS_URL
       value: https://axsys.prod-fss-pub.nais.io
     - name: AXSYS_SCOPE
@@ -84,8 +80,8 @@ spec:
       value: api://prod-fss.pdl.pdl-api/.default
     - name: PDL_URL
       value: https://pdl-api.prod-fss-pub.nais.io
-    - name: RUNTIME_LOCATION
-      value: GCP
+    - name: NORG_URL
+      value: https://norg2.prod-fss-pub.nais.io
     - name: AD_GRUPPE_ID_FORTROLIG_ADRESSE
       value: 9ec6487d-f37a-4aad-a027-cd221c1ac32b
     - name: AD_GRUPPE_ID_STRENGT_FORTROLIG_ADRESSE

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgConfig.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgConfig.kt
@@ -1,33 +1,16 @@
 package no.nav.poao_tilgang.application.client.norg
 
-import no.nav.common.token_client.client.MachineToMachineTokenClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
 open class NorgConfig(
-	@Value("\${runtimeLocation}") val runtimeLocation: String,
-	@Value("\${norg.url}") val norgUrl: String?,
-	@Value("\${poao-gcp-proxy.url}") val proxyUrl: String?,
-	@Value("\${poao-gcp-proxy.scope}") val proxyScope: String?
+	@Value("\${norg.url}") val norgUrl: String
 ) {
 
 	@Bean
-	open fun norgClient(machineToMachineTokenClient: MachineToMachineTokenClient): NorgClient {
-
-		val client = if (runtimeLocation == "GCP") {
-			check(proxyUrl != null) { "Missing required property proxyUrl" }
-			check(proxyScope != null) { "Missing required property proxyScope" }
-
-			NorgHttpClient(
-				"$proxyUrl/proxy/norg2",
-				{ machineToMachineTokenClient.createMachineToMachineToken(proxyScope) })
-		} else {
-			check(norgUrl != null) { "Missing required property norgUrl" }
-			NorgHttpClient(norgUrl, null)
-		}
-
-		return NorgCachedClient(client)
+	open fun norgClient(): NorgClient {
+		return NorgCachedClient(NorgHttpClient(norgUrl))
 	}
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
@@ -10,7 +10,6 @@ import org.springframework.http.HttpHeaders
 
 class NorgHttpClient(
 	private val baseUrl: String,
-	private val tokenProvider: (() -> String)?,
 	private val httpClient: OkHttpClient = RestClient.baseClient(),
 ) : NorgClient {
 
@@ -21,10 +20,6 @@ class NorgHttpClient(
 		val requestBuilder = Request.Builder()
 			.url(joinPaths(baseUrl, "/api/v1/enhet/navkontor/", geografiskTilknytning))
 			.get()
-
-		if (tokenProvider != null) {
-			requestBuilder.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + tokenProvider.invoke())
-		}
 
 		val request = requestBuilder.build()
 

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -23,9 +23,6 @@ skjermet_person.scope=${SKJERMET_PERSON_SCOPE:#{null}}
 microsoft_graph.url=${MICROSOFT_GRAPH_URL:#{null}}
 microsoft_graph.scope=${MICROSOFT_GRAPH_SCOPE:#{null}}
 
-poao-gcp-proxy.url=${POAO_GCP_PROXY_URL:#{null}}
-poao-gcp-proxy.scope=${POAO_GCP_PROXY_SCOPE:#{null}}
-
 axsys.url=${AXSYS_URL:#{null}}
 axsys.scope=${AXSYS_SCOPE:#{null}}
 
@@ -39,8 +36,6 @@ pdl.scope=${PDL_SCOPE:#{null}}
 pdl.url=${PDL_URL:#{null}}
 
 norg.url=${NORG_URL:#{null}}
-
-runtimeLocation=${RUNTIME_LOCATION:#{null}}
 
 ad-gruppe-id.fortrolig-adresse=${AD_GRUPPE_ID_FORTROLIG_ADRESSE:#{null}}
 ad-gruppe-id.strengt-fortrolig-adresse=${AD_GRUPPE_ID_STRENGT_FORTROLIG_ADRESSE:#{null}}

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClientTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClientTest.kt
@@ -27,8 +27,7 @@ class NorgHttpClientTest {
 	@Test
 	fun `hentTilhorendeEnhet skal lage riktig request og parse response`() {
 		val client = NorgHttpClient(
-			baseUrl = mockServer.serverUrl(),
-			tokenProvider = { "TOKEN" }
+			baseUrl = mockServer.serverUrl()
 		)
 
 		mockServer.mockTilhorendeEnhet(geografiskTilknytning = "12345", tilhorendeEnhet = "4321")
@@ -41,14 +40,12 @@ class NorgHttpClientTest {
 
 		request.path shouldBe "/api/v1/enhet/navkontor/12345"
 		request.method shouldBe "GET"
-		request.getHeader("Authorization") shouldBe "Bearer TOKEN"
 	}
 
 	@Test
 	fun `hentTilhorendeEnhet feiler hvis Norg returnerer 404`() {
 		val client = NorgHttpClient(
-			baseUrl = mockServer.serverUrl(),
-			tokenProvider = { "TOKEN" }
+			baseUrl = mockServer.serverUrl()
 		)
 
 		mockServer.mockIngenTilhorendeEnhet("23456")

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/IntegrationTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/IntegrationTest.kt
@@ -40,6 +40,7 @@ open class IntegrationTest {
 		val mockNorgHttpServer = MockNorgHttpServer()
 		val mockMachineToMachineHttpServer = MockMachineToMachineHttpServer()
 
+		@Suppress("UNUSED_PARAMETER")
 		@JvmStatic
 		@DynamicPropertySource
 		fun registerProperties(_registry: DynamicPropertyRegistry) {
@@ -57,8 +58,6 @@ open class IntegrationTest {
 				"AZURE_OPENID_CONFIG_TOKEN_ENDPOINT",
 				mockMachineToMachineHttpServer.serverUrl() + MockMachineToMachineHttpServer.tokenPath
 			)
-
-			System.setProperty("RUNTIME_LOCATION", "TEST")
 		}
 
 


### PR DESCRIPTION
Endret til pub-ingress for Norg2. Fjerner bruk av poao-gcp-proxy.