### PR TITLE
Legg til støtte for lesetilgang til ekstern bruker

### DIFF
--- a/api/src/main/kotlin/no/nav/poao_tilgang/api/dto/request/TilgangType.kt
+++ b/api/src/main/kotlin/no/nav/poao_tilgang/api/dto/request/TilgangType.kt
@@ -1,0 +1,5 @@
+package no.nav.poao_tilgang.api.dto.request
+
+enum class TilgangType {
+	LESE, SKRIVE
+}

--- a/api/src/main/kotlin/no/nav/poao_tilgang/api/dto/request/policy_input/NavAnsattTilgangTilEksternBrukerPolicyInputV2Dto.kt
+++ b/api/src/main/kotlin/no/nav/poao_tilgang/api/dto/request/policy_input/NavAnsattTilgangTilEksternBrukerPolicyInputV2Dto.kt
@@ -1,8 +1,10 @@
 package no.nav.poao_tilgang.api.dto.request.policy_input
 
+import no.nav.poao_tilgang.api.dto.request.TilgangType
 import java.util.*
 
 data class NavAnsattTilgangTilEksternBrukerPolicyInputV2Dto(
 	val navAnsattAzureId: UUID,
+	val tilgangType: TilgangType,
 	val norskIdent: String
 )

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/config/PolicyConfig.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/config/PolicyConfig.kt
@@ -16,6 +16,7 @@ open class PolicyConfig {
 		navAnsattTilgangTilSkjermetPersonPolicy: NavAnsattTilgangTilSkjermetPersonPolicy,
 		navAnsattTilgangTilEksternBrukerNavEnhetPolicy: NavAnsattTilgangTilEksternBrukerNavEnhetPolicy,
 		navAnsattTilgangTilOppfolgingPolicy: NavAnsattTilgangTilOppfolgingPolicy,
+		navAnsattTilgangTilModiaGenerellPolicy: NavAnsattTilgangTilModiaGenerellPolicy,
 		adGruppeProvider: AdGruppeProvider
 	): NavAnsattTilgangTilEksternBrukerPolicy {
 		return NavAnsattTilgangTilEksternBrukerPolicyImpl(
@@ -24,6 +25,7 @@ open class PolicyConfig {
 			navAnsattTilgangTilSkjermetPersonPolicy,
 			navAnsattTilgangTilEksternBrukerNavEnhetPolicy,
 			navAnsattTilgangTilOppfolgingPolicy,
+			navAnsattTilgangTilModiaGenerellPolicy,
 			adGruppeProvider
 		)
 	}
@@ -110,4 +112,8 @@ open class PolicyConfig {
 		return NavAnsattTilgangTilOppfolgingPolicyImpl(adGruppeProvider)
 	}
 
+	@Bean
+	open fun navAnsattTilgangTilModiaGenerellPolicy(adGruppeProvider: AdGruppeProvider): NavAnsattTilgangTilModiaGenerellPolicy {
+		return NavAnsattTilgangTilModiaGenerellPolicyImpl(adGruppeProvider)
+	}
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
@@ -18,6 +18,7 @@ import no.nav.poao_tilgang.application.utils.Issuer
 import no.nav.poao_tilgang.application.utils.JsonUtils.fromJsonNode
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.PolicyInput
+import no.nav.poao_tilgang.core.domain.TilgangType
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilEksternBrukerPolicy
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilModiaPolicy
 import no.nav.poao_tilgang.core.provider.AdGruppeProvider
@@ -63,7 +64,8 @@ class PolicyController(
 
 				NavAnsattTilgangTilEksternBrukerPolicy.Input(
 					navAnsattAzureId = adGruppeProvider.hentAzureIdMedNavIdent(dto.navIdent),
-					norskIdent = dto.norskIdent
+					norskIdent = dto.norskIdent,
+					tilgangType = TilgangType.SKRIVE
 				)
 			}
 			PolicyId.NAV_ANSATT_TILGANG_TIL_EKSTERN_BRUKER_V2 -> {
@@ -71,7 +73,11 @@ class PolicyController(
 
 				NavAnsattTilgangTilEksternBrukerPolicy.Input(
 					navAnsattAzureId = dto.navAnsattAzureId,
-					norskIdent = dto.norskIdent
+					norskIdent = dto.norskIdent,
+					tilgangType = when (dto.tilgangType) {
+						no.nav.poao_tilgang.api.dto.request.TilgangType.LESE -> TilgangType.LESE
+						no.nav.poao_tilgang.api.dto.request.TilgangType.SKRIVE -> TilgangType.SKRIVE
+					}
 				)
 			}
 			PolicyId.NAV_ANSATT_TILGANG_TIL_MODIA_V1 -> {

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/AbacProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/AbacProviderImpl.kt
@@ -4,14 +4,25 @@ import no.nav.common.abac.Pep
 import no.nav.common.abac.domain.request.ActionId
 import no.nav.common.types.identer.Fnr
 import no.nav.common.types.identer.NavIdent
+import no.nav.poao_tilgang.core.domain.TilgangType
 import no.nav.poao_tilgang.core.provider.AbacProvider
 import org.springframework.stereotype.Component
 
 @Component
 class AbacProviderImpl(private val pep: Pep) : AbacProvider {
 
-	override fun harVeilederTilgangTilPerson(veilederIdent: String, eksternBrukerId: String): Boolean {
-		return pep.harVeilederTilgangTilPerson(NavIdent.of(veilederIdent), ActionId.WRITE, Fnr.of(eksternBrukerId))
+	override fun harVeilederTilgangTilPerson(
+		veilederIdent: String,
+		tilgangType: TilgangType,
+		eksternBrukerId: String
+	): Boolean {
+
+		val action = when (tilgangType) {
+			TilgangType.LESE -> ActionId.READ
+			TilgangType.SKRIVE -> ActionId.WRITE
+		}
+
+		return pep.harVeilederTilgangTilPerson(NavIdent.of(veilederIdent), action, Fnr.of(eksternBrukerId))
 	}
 
 }

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockAbacHttpServer.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockAbacHttpServer.kt
@@ -1,14 +1,16 @@
 package no.nav.poao_tilgang.application.test_util.mock_clients
 
 import no.nav.poao_tilgang.application.test_util.MockHttpServer
+import no.nav.poao_tilgang.core.domain.TilgangType
 import okhttp3.mockwebserver.MockResponse
 
 class MockAbacHttpServer : MockHttpServer() {
 
-	fun mockPermit() {
+	fun mockPermit(tilgangType: TilgangType) {
 		handleRequest(
 			matchPath = "/",
 			matchMethod = "POST",
+			matchBodyContains = matchAbacTilgangAction(tilgangType),
 			response = MockResponse()
 				.setBody(
 					"""
@@ -30,10 +32,11 @@ class MockAbacHttpServer : MockHttpServer() {
 		)
 	}
 
-	fun mockDeny() {
+	fun mockDeny(tilgangType: TilgangType) {
 		handleRequest(
 			matchPath = "/",
 			matchMethod = "POST",
+			matchBodyContains = matchAbacTilgangAction(tilgangType),
 			response = MockResponse()
 				.setBody(
 					"""
@@ -84,4 +87,11 @@ class MockAbacHttpServer : MockHttpServer() {
 		)
 	}
 
+	private fun matchAbacTilgangAction(tilgangType: TilgangType): String {
+		val action = when(tilgangType) {
+			TilgangType.LESE -> "read"
+			TilgangType.SKRIVE -> "update"
+		}
+		return """"Value": "$action""""
+	}
 }

--- a/client/src/main/kotlin/no/nav/poao_tilgang/client/PoaoTilgangHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/poao_tilgang/client/PoaoTilgangHttpClient.kt
@@ -141,7 +141,11 @@ class PoaoTilgangHttpClient(
 				requestId = policyRequest.requestId,
 				policyInput = NavAnsattTilgangTilEksternBrukerPolicyInputV2Dto(
 					navAnsattAzureId = policyRequest.policyInput.navAnsattAzureId,
-					norskIdent = policyRequest.policyInput.norskIdent
+					norskIdent = policyRequest.policyInput.norskIdent,
+					tilgangType = when(policyRequest.policyInput.tilgangType) {
+						TilgangType.LESE -> no.nav.poao_tilgang.api.dto.request.TilgangType.LESE
+						TilgangType.SKRIVE -> no.nav.poao_tilgang.api.dto.request.TilgangType.SKRIVE
+					}
 				),
 				policyId = PolicyId.NAV_ANSATT_TILGANG_TIL_EKSTERN_BRUKER_V2
 			)

--- a/client/src/main/kotlin/no/nav/poao_tilgang/client/PolicyInput.kt
+++ b/client/src/main/kotlin/no/nav/poao_tilgang/client/PolicyInput.kt
@@ -2,13 +2,19 @@ package no.nav.poao_tilgang.client
 
 import java.util.*
 
+enum class TilgangType {
+	LESE, SKRIVE
+}
+
 sealed class PolicyInput
 
 data class NavAnsattTilgangTilEksternBrukerPolicyInput(
 	val navAnsattAzureId: UUID,
+	val tilgangType: TilgangType,
 	val norskIdent: String
 ) : PolicyInput()
 
 data class NavAnsattTilgangTilModiaPolicyInput(
 	val navAnsattAzureId: UUID
 ) : PolicyInput()
+

--- a/client/src/test/kotlin/no/nav/poao_tilgang/client/PoaoTilgangCachedClientTest.kt
+++ b/client/src/test/kotlin/no/nav/poao_tilgang/client/PoaoTilgangCachedClientTest.kt
@@ -22,7 +22,7 @@ class PoaoTilgangCachedClientTest {
 
 	@Test
 	fun `evaluatePolicy - skal cache og returnere decision`() {
-		val input = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), "1321321321")
+		val input = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), TilgangType.LESE, "1321321321")
 		every { client.evaluatePolicy(input) } returns ApiResult.success(Decision.Permit)
 
 		val result = cachedClient.evaluatePolicy(input)
@@ -34,17 +34,19 @@ class PoaoTilgangCachedClientTest {
 
 	@Test
 	fun `evaluatePolicy - skal cache riktig input`() {
-		val input = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), "1321321321")
+		val input = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), TilgangType.LESE, "1321321321")
 		val input2 = NavAnsattTilgangTilModiaPolicyInput(UUID.randomUUID())
-		val input3 = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), "6464654654")
+		val input3 = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), TilgangType.LESE, "6464654654")
+		val input4 = NavAnsattTilgangTilEksternBrukerPolicyInput(UUID.randomUUID(), TilgangType.SKRIVE, "6464654654")
 
 		every { client.evaluatePolicy(any()) } returns ApiResult.success(Decision.Permit)
 
 		cachedClient.evaluatePolicy(input)
 		cachedClient.evaluatePolicy(input2)
 		cachedClient.evaluatePolicy(input3)
+		cachedClient.evaluatePolicy(input4)
 
-		verify (exactly = 3) { client.evaluatePolicy(any()) }
+		verify (exactly = 4) { client.evaluatePolicy(any()) }
 	}
 
 	@Test

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/TilgangType.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/TilgangType.kt
@@ -1,0 +1,5 @@
+package no.nav.poao_tilgang.core.domain
+
+enum class TilgangType {
+	LESE, SKRIVE
+}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
@@ -9,6 +9,7 @@ interface NavAnsattTilgangTilEksternBrukerPolicy : Policy<NavAnsattTilgangTilEks
 
 	data class Input(
 		val navAnsattAzureId: AzureObjectId,
+		val tilgangType: TilgangType,
 		val norskIdent: NorskIdent
 	) : PolicyInput
 

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilModiaGenerellPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilModiaGenerellPolicy.kt
@@ -1,0 +1,16 @@
+package no.nav.poao_tilgang.core.policy
+
+import no.nav.poao_tilgang.core.domain.AzureObjectId
+import no.nav.poao_tilgang.core.domain.Policy
+import no.nav.poao_tilgang.core.domain.PolicyInput
+
+/**
+ * Sjekker om en NAV ansatt har generell tilgang til å bruke Modia flaten
+ */
+interface NavAnsattTilgangTilModiaGenerellPolicy : Policy<NavAnsattTilgangTilModiaGenerellPolicy.Input> {
+
+	data class Input (
+		val navAnsattAzureId: AzureObjectId
+	) : PolicyInput
+
+}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilModiaGenerellPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilModiaGenerellPolicyImpl.kt
@@ -1,0 +1,25 @@
+package no.nav.poao_tilgang.core.policy.impl
+
+import no.nav.poao_tilgang.core.domain.Decision
+import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilModiaGenerellPolicy
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import no.nav.poao_tilgang.core.utils.hasAtLeastOne
+
+class NavAnsattTilgangTilModiaGenerellPolicyImpl(
+	private val adGruppeProvider: AdGruppeProvider
+) : NavAnsattTilgangTilModiaGenerellPolicy {
+
+	private val tilgangTilModiaGrupper = adGruppeProvider.hentTilgjengeligeAdGrupper().let {
+		listOf(
+			it.modiaGenerell,
+			it.modiaOppfolging
+		)
+	}
+
+	override val name = "NavAnsattTilgangTilModiaGenerellPolicy"
+
+	override fun evaluate(input: NavAnsattTilgangTilModiaGenerellPolicy.Input): Decision {
+		return adGruppeProvider.hentAdGrupper(input.navAnsattAzureId)
+			.hasAtLeastOne(tilgangTilModiaGrupper)
+	}
+}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/AbacProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/AbacProvider.kt
@@ -1,7 +1,13 @@
 package no.nav.poao_tilgang.core.provider
 
+import no.nav.poao_tilgang.core.domain.TilgangType
+
 interface AbacProvider {
 
-	fun harVeilederTilgangTilPerson(veilederIdent: String, eksternBrukerId: String): Boolean
+	fun harVeilederTilgangTilPerson(
+		veilederIdent: String,
+		tilgangType: TilgangType,
+		eksternBrukerId: String
+	): Boolean
 
 }

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilModiaGenerellPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilModiaGenerellPolicyImplTest.kt
@@ -1,0 +1,79 @@
+package no.nav.poao_tilgang.core.policy.impl
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.poao_tilgang.core.domain.Decision
+import no.nav.poao_tilgang.core.domain.DecisionDenyReason
+import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilModiaGenerellPolicy
+import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.randomGruppe
+import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class NavAnsattTilgangTilModiaGenerellPolicyImplTest {
+
+	private val adGruppeProvider = mockk<AdGruppeProvider>()
+
+	private lateinit var policy: NavAnsattTilgangTilModiaGenerellPolicy
+
+	private val navAnsattAzureId = UUID.randomUUID()
+
+	@BeforeEach
+	internal fun setUp() {
+		every {
+			adGruppeProvider.hentTilgjengeligeAdGrupper()
+		} returns testAdGrupper
+
+		policy = NavAnsattTilgangTilModiaGenerellPolicyImpl(adGruppeProvider)
+	}
+
+	@Test
+	fun `should return "permit" if access to 0000-GA-BD06_ModiaGenerellTilgang`() {
+
+		every {
+			adGruppeProvider.hentAdGrupper(navAnsattAzureId)
+		} returns listOf(
+			testAdGrupper.modiaGenerell,
+			randomGruppe
+		)
+
+		policy.evaluate(NavAnsattTilgangTilModiaGenerellPolicy.Input(navAnsattAzureId)) shouldBe Decision.Permit
+	}
+
+	@Test
+	fun `should return "permit" if access to 0000-GA-Modia-Oppfolging`() {
+
+		every {
+			adGruppeProvider.hentAdGrupper(navAnsattAzureId)
+		} returns listOf(
+			testAdGrupper.modiaOppfolging,
+			randomGruppe,
+		)
+
+		policy.evaluate(NavAnsattTilgangTilModiaGenerellPolicy.Input(navAnsattAzureId)) shouldBe Decision.Permit
+	}
+
+
+	@Test
+	fun `should return "deny" if missing access to ad groups`() {
+
+		every {
+			adGruppeProvider.hentAdGrupper(navAnsattAzureId)
+		} returns listOf(
+			randomGruppe
+		)
+
+		val decision = policy.evaluate(NavAnsattTilgangTilModiaGenerellPolicy.Input(navAnsattAzureId))
+
+		decision.type shouldBe Decision.Type.DENY
+
+		if (decision is Decision.Deny) {
+			decision.message shouldBe "NAV-ansatt mangler tilgang til en av AD-gruppene [0000-GA-BD06_ModiaGenerellTilgang, 0000-GA-Modia-Oppfolging]"
+			decision.reason shouldBe DecisionDenyReason.MANGLER_TILGANG_TIL_AD_GRUPPE
+		}
+	}
+
+}


### PR DESCRIPTION
Tidligere implementasjon var kun skrivetilgang, utvidet med støtter for både lese- og skrivetilgang.