### PR TITLE
Policy for medlem av AD-gruppe

### DIFF
--- a/client/src/main/kotlin/no/nav/poao_tilgang/client/PolicyInput.kt
+++ b/client/src/main/kotlin/no/nav/poao_tilgang/client/PolicyInput.kt
@@ -22,3 +22,24 @@ data class EksternBrukerTilgangTilEksternBrukerPolicyInput(
 	val rekvirentNorskIdent: String, // Den som ber om tilgang
 	val ressursNorskIdent: String // Den som bes tilgang om
 ) : PolicyInput()
+
+data class NavAnsattMedlemAvAdGruppePolicyInput(
+	val navAnsattAzureId: UUID,
+	val adGruppeId: UUID
+) : PolicyInput()
+
+data class NavAnsattBehandleStrengtFortroligUtlandBrukerePolicyInput(
+	val navAnsattAzureId: UUID
+) : PolicyInput()
+
+data class NavAnsattBehandleSkjermedePersonerPolicyInput(
+	val navAnsattAzureId: UUID
+) : PolicyInput()
+
+data class NavAnsattBehandleStrengtFortroligBrukerePolicyInput(
+	val navAnsattAzureId: UUID
+) : PolicyInput()
+
+data class NavAnsattBehandleFortroligBrukerePolicyInput(
+	val navAnsattAzureId: UUID
+) : PolicyInput()

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattMedlemAvAdGruppePolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattMedlemAvAdGruppePolicy.kt
@@ -1,0 +1,18 @@
+package no.nav.poao_tilgang.core.policy
+
+import no.nav.poao_tilgang.core.domain.AzureObjectId
+import no.nav.poao_tilgang.core.domain.Policy
+import no.nav.poao_tilgang.core.domain.PolicyInput
+import java.util.*
+
+/**
+ * Sjekker om en NAV ansatt er medlen av AD-gruppe
+ */
+interface NavAnsattMedlemAvAdGruppePolicy : Policy<NavAnsattMedlemAvAdGruppePolicy.Input> {
+
+	data class Input (
+		val navAnsattAzureId: AzureObjectId,
+		val adGruppeId: UUID
+	) : PolicyInput
+
+}


### PR DESCRIPTION
Starter draft for hvordan vi kan utvide med sjekker for å finne ut om en veileder er medlem av en vilkårlig AD-gruppe. Også med spesialiserte inputs for vanlige
AD-gruppe-sjekker: fortrolig, streng fortrolig, strengt fortrolig utland, skjerming.