### PR TITLE
Bruk ABAC sin decision i NavAnsattTilgangTilNavEnhetPolicy

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/config/PolicyConfig.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/config/PolicyConfig.kt
@@ -73,10 +73,11 @@ open class PolicyConfig {
 	@Bean
 	open fun tilgangTilNavEnhetPolicy(
 		navEnhetTilgangProvider: NavEnhetTilgangProvider,
-		adGruppeProvider: AdGruppeProvider
+		adGruppeProvider: AdGruppeProvider,
+		abacProvider: AbacProvider
 	): NavAnsattTilgangTilNavEnhetPolicy {
 		return NavAnsattTilgangTilNavEnhetPolicyImpl(
-			navEnhetTilgangProvider, adGruppeProvider
+			navEnhetTilgangProvider, adGruppeProvider, abacProvider
 		)
 	}
 

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/AbacProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/AbacProviderImpl.kt
@@ -2,6 +2,7 @@ package no.nav.poao_tilgang.application.provider
 
 import no.nav.common.abac.Pep
 import no.nav.common.abac.domain.request.ActionId
+import no.nav.common.types.identer.EnhetId
 import no.nav.common.types.identer.Fnr
 import no.nav.common.types.identer.NavIdent
 import no.nav.poao_tilgang.core.domain.TilgangType
@@ -23,6 +24,10 @@ class AbacProviderImpl(private val pep: Pep) : AbacProvider {
 		}
 
 		return pep.harVeilederTilgangTilPerson(NavIdent.of(veilederIdent), action, Fnr.of(eksternBrukerId))
+	}
+
+	override fun harVeilederTilgangTilNavEnhet(veilederIdent: String, navEnhetId: String): Boolean {
+		return pep.harVeilederTilgangTilEnhet(NavIdent.of(veilederIdent), EnhetId.of(navEnhetId))
 	}
 
 }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerPolicyImpl.kt
@@ -1,15 +1,12 @@
 package no.nav.poao_tilgang.core.policy.impl
 
-import kotlinx.coroutines.slf4j.MDCContext
 import no.nav.poao_tilgang.core.domain.Decision
-import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.domain.TilgangType
 import no.nav.poao_tilgang.core.policy.*
 import no.nav.poao_tilgang.core.provider.AbacProvider
 import no.nav.poao_tilgang.core.provider.AdGruppeProvider
-import org.slf4j.LoggerFactory
-
-import kotlinx.coroutines.*
+import no.nav.poao_tilgang.core.utils.AbacDecisionDiff.asyncLogDecisionDiff
+import no.nav.poao_tilgang.core.utils.AbacDecisionDiff.toAbacDecision
 
 class NavAnsattTilgangTilEksternBrukerPolicyImpl(
 	private val abacProvider: AbacProvider,
@@ -21,15 +18,12 @@ class NavAnsattTilgangTilEksternBrukerPolicyImpl(
 	private val adGruppeProvider: AdGruppeProvider
 ) : NavAnsattTilgangTilEksternBrukerPolicy {
 
-	private val log = LoggerFactory.getLogger(javaClass)
-	private val secureLog = LoggerFactory.getLogger("SecureLog")
-
 	override val name = "NavAnsattTilgangTilEksternBruker"
 
 	override fun evaluate(input: NavAnsattTilgangTilEksternBrukerPolicy.Input): Decision {
 		val harTilgangAbac = harTilgangAbac(input)
 
-		asyncLogDecisionDiff(input, harTilgangAbac)
+		asyncLogDecisionDiff(name, input, ::harTilgang, harTilgangAbac)
 
 		return harTilgangAbac
 	}
@@ -40,27 +34,7 @@ class NavAnsattTilgangTilEksternBrukerPolicyImpl(
 		val navIdent = adGruppeProvider.hentNavIdentMedAzureId(navAnsattAzureId)
 		val harTilgang = abacProvider.harVeilederTilgangTilPerson(navIdent, tilgangType, norskIdent)
 
-		return if (harTilgang) Decision.Permit else Decision.Deny(
-			"Deny fra ABAC",
-			DecisionDenyReason.IKKE_TILGANG_FRA_ABAC
-		)
-	}
-
-	@OptIn(DelicateCoroutinesApi::class)
-	private fun asyncLogDecisionDiff(input: NavAnsattTilgangTilEksternBrukerPolicy.Input, harTilgangAbac: Decision) {
-		GlobalScope.launch(MDCContext()) {
-			try {
-				val harTilgang = harTilgang(input)
-
-				if (harTilgangAbac != harTilgang) {
-					secureLog.info("Decision diff - ulikt svar: ABAC=($harTilgangAbac) POAO-tilgang=($harTilgang) Input=$input")
-				} else {
-					secureLog.info("Decision diff - likt svar: ABAC=($harTilgangAbac) POAO-tilgang=($harTilgang) Input=$input")
-				}
-			} catch (e: Throwable) {
-				log.error("Feil i POAO-tilgang implementasjon", e)
-			}
-		}
+		return toAbacDecision(harTilgang)
 	}
 
 	// Er ikke private slik at vi kan teste implementasjonen

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImpl.kt
@@ -3,13 +3,17 @@ package no.nav.poao_tilgang.core.policy.impl
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilNavEnhetPolicy
+import no.nav.poao_tilgang.core.provider.AbacProvider
 import no.nav.poao_tilgang.core.provider.AdGruppeProvider
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import no.nav.poao_tilgang.core.utils.AbacDecisionDiff.asyncLogDecisionDiff
+import no.nav.poao_tilgang.core.utils.AbacDecisionDiff.toAbacDecision
 import no.nav.poao_tilgang.core.utils.has
 
 class NavAnsattTilgangTilNavEnhetPolicyImpl(
 	private val navEnhetTilgangProvider: NavEnhetTilgangProvider,
-	private val adGruppeProvider: AdGruppeProvider
+	private val adGruppeProvider: AdGruppeProvider,
+	private val abacProvider: AbacProvider
 ) : NavAnsattTilgangTilNavEnhetPolicy {
 
 	private val modiaAdmin = adGruppeProvider.hentTilgjengeligeAdGrupper().modiaAdmin
@@ -22,6 +26,21 @@ class NavAnsattTilgangTilNavEnhetPolicyImpl(
 	override val name = "NavAnsattTilgangTilNavEnhet"
 
 	override fun evaluate(input: NavAnsattTilgangTilNavEnhetPolicy.Input): Decision {
+		val harTilgangAbac = harTilgangAbac(input)
+
+		asyncLogDecisionDiff(name, input, ::harTilgang, harTilgangAbac)
+
+		return harTilgangAbac
+	}
+
+	private fun harTilgangAbac(input: NavAnsattTilgangTilNavEnhetPolicy.Input): Decision {
+		val navIdent = adGruppeProvider.hentNavIdentMedAzureId(input.navAnsattAzureId)
+		val harTilgangAbac = abacProvider.harVeilederTilgangTilNavEnhet(navIdent, input.navEnhetId)
+		return toAbacDecision(harTilgangAbac)
+	}
+
+	// Er ikke private slik at vi kan teste implementasjonen
+	internal fun harTilgang(input: NavAnsattTilgangTilNavEnhetPolicy.Input): Decision {
 		adGruppeProvider.hentAdGrupper(input.navAnsattAzureId)
 			.has(modiaAdmin)
 			.whenPermit { return it }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/AbacProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/AbacProvider.kt
@@ -10,4 +10,9 @@ interface AbacProvider {
 		eksternBrukerId: String
 	): Boolean
 
+	fun harVeilederTilgangTilNavEnhet(
+		veilederIdent: String,
+		navEnhetId: String
+	): Boolean
+
 }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/utils/AbacDecisionDiff.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/utils/AbacDecisionDiff.kt
@@ -1,0 +1,42 @@
+package no.nav.poao_tilgang.core.utils
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.slf4j.MDCContext
+import no.nav.poao_tilgang.core.domain.Decision
+import no.nav.poao_tilgang.core.domain.DecisionDenyReason
+import no.nav.poao_tilgang.core.domain.PolicyInput
+import org.slf4j.LoggerFactory
+
+object AbacDecisionDiff {
+
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	private val secureLog = LoggerFactory.getLogger("SecureLog")
+
+	fun toAbacDecision(harTilgangAbac: Boolean): Decision {
+		return if (harTilgangAbac) Decision.Permit else Decision.Deny(
+			"Deny fra ABAC",
+			DecisionDenyReason.IKKE_TILGANG_FRA_ABAC
+		)
+	}
+
+	@OptIn(DelicateCoroutinesApi::class)
+	fun <I : PolicyInput> asyncLogDecisionDiff(policyName: String, input: I, policy: (input: I) -> Decision, abacDecision: Decision) {
+		GlobalScope.launch(MDCContext()) {
+			try {
+				val poaoTilgangDecision = policy.invoke(input)
+
+				if (abacDecision != poaoTilgangDecision) {
+					secureLog.info("Decision diff for policy $policyName - ulikt svar: ABAC=($abacDecision) POAO-tilgang=($poaoTilgangDecision) Input=$input")
+				} else {
+					secureLog.info("Decision diff for policy $policyName - likt svar: ABAC=($abacDecision) POAO-tilgang=($poaoTilgangDecision) Input=$input")
+				}
+			} catch (e: Throwable) {
+				log.error("Feil i POAO-tilgang implementasjon", e)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Koden i abac-veilarb sier ingen ting om enheter som det sjekkes tilgang på er filtrert på tema OPP eller ikke.
Istedenfor å bruke poao-tilgang sin implementasjon så bruker vi ABAC enn så lenge med decision diff til vi er sikre på at vi har implementert reglen riktig.