### PR TITLE
Fjerner policykall

### DIFF
--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerPolicyImpl.kt
@@ -54,27 +54,6 @@ class NavAnsattTilgangTilEksternBrukerPolicyImpl(
 				).whenPermit { return it }
 		}
 
-		navAnsattTilgangTilAdressebeskyttetBrukerPolicy.evaluate(
-			NavAnsattTilgangTilAdressebeskyttetBrukerPolicy.Input(
-				navAnsattAzureId = navAnsattAzureId,
-				norskIdent = norskIdent
-			)
-		).whenPermit { return it }
-
-		navAnsattTilgangTilSkjermetPersonPolicy.evaluate(
-			NavAnsattTilgangTilSkjermetPersonPolicy.Input(
-				navAnsattAzureId = navAnsattAzureId,
-				norskIdent = norskIdent
-			)
-		).whenPermit { return it }
-
-		navAnsattTilgangTilEksternBrukerNavEnhetPolicy.evaluate(
-			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(
-				navAnsattAzureId = navAnsattAzureId,
-				norskIdent = norskIdent
-			)
-		).whenPermit { return it }
-
 		return Decision.Deny(
 			message = "NavAnsatt har ikke tilgang til ekstern bruker",
 			reason = DecisionDenyReason.UKLAR_TILGANG_MANGLENDE_INFORMASJON


### PR DESCRIPTION
I sjekken NavAnsattTilgangTilEksternBruker har vi kalt tre policyer som vi ikke ser at man kaller i abac. Vi tror derfor at det er feil at de skal ligge der og at de bør fjernes for å fjerne diffene mellom poao-tilgang og abac.