### PR TITLE
Øker initalDelay før helsesjekk fra 20 til 60.

### DIFF
--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -15,10 +15,10 @@ spec:
     path: /internal/prometheus
   readiness:
     path: /internal/health/readiness
-    initialDelay: 20
+    initialDelay: 60
   liveness:
     path: /internal/health/liveness
-    initialDelay: 20
+    initialDelay: 60
   replicas:
     min: 2
     max: 4


### PR DESCRIPTION
Årsak er at vi ser timeouts ved deploy av poao-tilgang, og tror det er fordi nye podder får trafikk før de er klare