### PR TITLE
334 handtere404 fra norg

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgCachedClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgCachedClient.kt
@@ -2,7 +2,7 @@ package no.nav.poao_tilgang.application.client.norg
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
-import no.nav.poao_tilgang.application.utils.CacheUtils.tryCacheFirstNotNull
+import no.nav.poao_tilgang.application.utils.CacheUtils.tryCacheFirstNullable
 import no.nav.poao_tilgang.core.domain.NavEnhetId
 import java.util.concurrent.TimeUnit
 
@@ -12,9 +12,9 @@ class NorgCachedClient(private val norgClient: NorgClient) : NorgClient {
         .expireAfterWrite(12, TimeUnit.HOURS)
         .build()
 
-	override fun hentTilhorendeEnhet(geografiskTilknytning: String): NavEnhetId {
-        return tryCacheFirstNotNull(hentTilhorendeNavEnhetIdCache, geografiskTilknytning) {
-			norgClient.hentTilhorendeEnhet(geografiskTilknytning)
+	override fun hentTilhorendeEnhet(geografiskTilknytning: String): NavEnhetId? {
+        return tryCacheFirstNullable(hentTilhorendeNavEnhetIdCache, geografiskTilknytning) {
+			return@tryCacheFirstNullable norgClient.hentTilhorendeEnhet(geografiskTilknytning)
 		}
 	}
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgClient.kt
@@ -8,5 +8,5 @@ interface NorgClient {
      * @param geografiskTilknytning Geografisk identifikator, kommune eller bydel, for NAV kontoret (f.eks NAV Frogner tilhører 030105)
      * @return NAV enhet som tilhører det geografiske området
      */
-    fun hentTilhorendeEnhet(geografiskTilknytning: String): NavEnhetId
+    fun hentTilhorendeEnhet(geografiskTilknytning: String): NavEnhetId?
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
@@ -4,6 +4,7 @@ import io.micrometer.core.annotation.Timed
 import no.nav.common.rest.client.RestClient
 import no.nav.common.utils.UrlUtils.joinPaths
 import no.nav.poao_tilgang.application.utils.JsonUtils.fromJsonString
+import no.nav.poao_tilgang.application.utils.SecureLog
 import no.nav.poao_tilgang.core.domain.NavEnhetId
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -28,13 +29,15 @@ open class NorgHttpClient(
 
 			if (!response.isSuccessful) {
 				if (response.code == 404) {
-					throw ExpectedExceptionFromNorg()
+						SecureLog.secureLog.info("Fant ikke NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning i Norg.")
+						return null
+					}
 				} else {
 					throw RuntimeException(
 						"Klarte ikke å hente NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning fra Norg. Status: ${response.code}"
 					)
 				}
-			}
+
 
 			val body = response.body?.string() ?: throw RuntimeException("Body is missing")
 

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClient.kt
@@ -14,7 +14,12 @@ open class NorgHttpClient(
 	private val httpClient: OkHttpClient = RestClient.baseClient(),
 ) : NorgClient {
 
-	@Timed("norg_http_client.hent_tilhorende_enhet", histogram = true, percentiles = [0.5, 0.95, 0.99], extraTags = ["type", "client"])
+	@Timed(
+		"norg_http_client.hent_tilhorende_enhet",
+		histogram = true,
+		percentiles = [0.5, 0.95, 0.99],
+		extraTags = ["type", "client"]
+	)
 	override fun hentTilhorendeEnhet(
 		geografiskTilknytning: String,
 	): NavEnhetId? {
@@ -27,17 +32,16 @@ open class NorgHttpClient(
 
 		httpClient.newCall(request).execute().use { response ->
 
-			if (!response.isSuccessful) {
-				if (response.code == 404) {
-						SecureLog.secureLog.info("Fant ikke NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning i Norg.")
-						return null
-					}
-				} else {
-					throw RuntimeException(
-						"Klarte ikke å hente NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning fra Norg. Status: ${response.code}"
-					)
-				}
+			if (response.code == 404) {
+				SecureLog.secureLog.info("Fant ikke NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning i Norg.")
+				return null
+			}
 
+			if (!response.isSuccessful) {
+				throw RuntimeException(
+					"Klarte ikke å hente NAV-enhet basert på geografisk tilknytning = $geografiskTilknytning fra Norg. Status: ${response.code}"
+				)
+			}
 
 			val body = response.body?.string() ?: throw RuntimeException("Body is missing")
 

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImpl.kt
@@ -14,7 +14,7 @@ class GeografiskTilknyttetEnhetProviderImpl(
 	private val norgClient: NorgClient
 ) : GeografiskTilknyttetEnhetProvider {
 
-	override fun hentGeografiskTilknytetEnhet(norskIdent: NorskIdent): NavEnhetId? {
+	override fun hentGeografiskTilknyttetEnhet(norskIdent: NorskIdent): NavEnhetId? {
 		val brukerInfo = pdlClient.hentBrukerInfo(norskIdent)
 
 		return brukerInfo.geografiskTilknytning

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/ExpectedExceptionFromNorg.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/ExpectedExceptionFromNorg.kt
@@ -1,0 +1,5 @@
+package no.nav.poao_tilgang.application.client.norg
+
+class ExpectedExceptionFromNorg : Exception() {
+
+}

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/ExpectedExceptionFromNorg.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/ExpectedExceptionFromNorg.kt
@@ -1,5 +1,0 @@
-package no.nav.poao_tilgang.application.client.norg
-
-class ExpectedExceptionFromNorg : Exception() {
-
-}

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClientTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/client/norg/NorgHttpClientTest.kt
@@ -1,6 +1,5 @@
 package no.nav.poao_tilgang.application.client.norg
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import no.nav.poao_tilgang.application.test_util.mock_clients.MockNorgHttpServer
 import org.junit.jupiter.api.AfterEach
@@ -43,13 +42,15 @@ class NorgHttpClientTest {
 	}
 
 	@Test
-	fun `hentTilhorendeEnhet feiler hvis Norg returnerer 404`() {
+	fun `hentTilhorendeEnhet skal returnere null hvis Norg returnerer 404`() {
 		val client = NorgHttpClient(
 			baseUrl = mockServer.serverUrl()
 		)
 
 		mockServer.mockIngenTilhorendeEnhet("23456")
 
-		shouldThrow<RuntimeException> { client.hentTilhorendeEnhet("23456") }
+		val geografiskTilknyttetEnhet = client.hentTilhorendeEnhet("23456")
+
+		geografiskTilknyttetEnhet shouldBe null
 	}
 }

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImplIntegrationTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImplIntegrationTest.kt
@@ -19,7 +19,7 @@ class GeografiskTilknyttetEnhetProviderImplIntegrationTest : IntegrationTest() {
 		)
 		mockNorgHttpServer.mockTilhorendeEnhet(geografiskTilknytning = "0570", tilhorendeEnhet = "1234")
 
-		geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet("987") shouldBe "1234"
+		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("987") shouldBe "1234"
 	}
 
 	@Test
@@ -29,7 +29,7 @@ class GeografiskTilknyttetEnhetProviderImplIntegrationTest : IntegrationTest() {
 		)
 		mockNorgHttpServer.mockTilhorendeEnhet(geografiskTilknytning = "057021", tilhorendeEnhet = "1235")
 
-		geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet("988") shouldBe "1235"
+		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("988") shouldBe "1235"
 	}
 
 	@Test
@@ -38,7 +38,7 @@ class GeografiskTilknyttetEnhetProviderImplIntegrationTest : IntegrationTest() {
 			norskIdent = "989", gtType = "UTLAND"
 		)
 
-		geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet("989") shouldBe null
+		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("989") shouldBe null
 	}
 
 	@Test
@@ -50,7 +50,7 @@ class GeografiskTilknyttetEnhetProviderImplIntegrationTest : IntegrationTest() {
 		mockNorgHttpServer.mockIngenTilhorendeEnhet("9999")
 
 		shouldThrow<RuntimeException> {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet("990")
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("990")
 		}
 	}
 }

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImplIntegrationTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/GeografiskTilknyttetEnhetProviderImplIntegrationTest.kt
@@ -42,15 +42,13 @@ class GeografiskTilknyttetEnhetProviderImplIntegrationTest : IntegrationTest() {
 	}
 
 	@Test
-	fun `feiler dersom tilhørende enhet for geografisk tilknyting ikke finnes`() {
+	fun `skal returnere null dersom tilhørende enhet for geografisk tilknyting ikke finnes`() {
 		mockPdlHttpServer.mockBrukerInfo(
 			norskIdent = "990", gtType = "KOMMUNE", gtKommune = "9999"
 		)
 
 		mockNorgHttpServer.mockIngenTilhorendeEnhet("9999")
 
-		shouldThrow<RuntimeException> {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("990")
-		}
+		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet("990") shouldBe null
 	}
 }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -5,13 +5,11 @@ import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.domain.NavEnhetId
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilEksternBrukerNavEnhetPolicy
-import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilNavEnhetPolicy
 import no.nav.poao_tilgang.core.provider.AdGruppeProvider
 import no.nav.poao_tilgang.core.provider.GeografiskTilknyttetEnhetProvider
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
 import no.nav.poao_tilgang.core.provider.OppfolgingsenhetProvider
 import no.nav.poao_tilgang.core.utils.hasAtLeastOne
-import javax.ws.rs.NotFoundException
 import org.slf4j.LoggerFactory
 
 class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
@@ -44,13 +42,9 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 			.hasAtLeastOne(nasjonalTilgangGrupper)
 			.whenPermit { return it }
 
-		try {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)?.let { navEnhetId ->
+		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)?.let { navEnhetId ->
 				harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "geografiskEnhet")
 					.whenPermit { return it }
-			}
-		} catch (e: ExpectedExceptionFromNorg){
-			Decision.Deny("", DecisionDenyReason.UKLAR_TILGANG_MANGLENDE_INFORMASJON)
 		}
 
 		oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)?.let { navEnhetId ->

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -43,19 +43,23 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 			.whenPermit { return it }
 
 		geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)?.let { navEnhetId ->
-				harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "geografiskEnhet")
-					.whenPermit { return it }
+			harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "geografiskEnhet")
+				.whenPermit { return it }
 		}
 
 		oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)?.let { navEnhetId ->
 			harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "oppfolgingsEnhet")
-			.whenPermit { return it }
+				.whenPermit { return it }
 		}
 
 		return denyDecision
 	}
 
-	fun harTilgangTilEnhetForBruker(navAnsattAzureId: AzureObjectId, navEnhetId: NavEnhetId, typeEnhet: String): Decision {
+	fun harTilgangTilEnhetForBruker(
+		navAnsattAzureId: AzureObjectId,
+		navEnhetId: NavEnhetId,
+		typeEnhet: String
+	): Decision {
 		val navIdent = adGruppeProvider.hentNavIdentMedAzureId(navAnsattAzureId)
 		val harTilgangTilEnhet = navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 			.any { navEnhetId == it.enhetId }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -11,6 +11,7 @@ import no.nav.poao_tilgang.core.provider.GeografiskTilknyttetEnhetProvider
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
 import no.nav.poao_tilgang.core.provider.OppfolgingsenhetProvider
 import no.nav.poao_tilgang.core.utils.hasAtLeastOne
+import javax.ws.rs.NotFoundException
 import org.slf4j.LoggerFactory
 
 class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
@@ -43,10 +44,15 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 			.hasAtLeastOne(nasjonalTilgangGrupper)
 			.whenPermit { return it }
 
-		geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)?.let { navEnhetId ->
-			harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "geografiskEnhet")
-			.whenPermit { return it }
+		try {
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)?.let { navEnhetId ->
+				harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "geografiskEnhet")
+					.whenPermit { return it }
+			}
+		} catch (e: ExpectedExceptionFromNorg){
+			Decision.Deny("", DecisionDenyReason.UKLAR_TILGANG_MANGLENDE_INFORMASJON)
 		}
+
 		oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)?.let { navEnhetId ->
 			harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "oppfolgingsEnhet")
 			.whenPermit { return it }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/GeografiskTilknyttetEnhetProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/GeografiskTilknyttetEnhetProvider.kt
@@ -5,5 +5,5 @@ import no.nav.poao_tilgang.core.domain.NorskIdent
 
 interface GeografiskTilknyttetEnhetProvider {
 
-	fun hentGeografiskTilknytetEnhet(norskIdent: NorskIdent): NavEnhetId?
+	fun hentGeografiskTilknyttetEnhet(norskIdent: NorskIdent): NavEnhetId?
 }

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
@@ -11,6 +11,7 @@ import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
 import no.nav.poao_tilgang.core.provider.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.net.http.HttpResponse
 import java.util.UUID
 
 class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
@@ -232,6 +233,31 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 			message = "Brukeren har ikke oppfølgingsenhet eller geografisk enhet",
 			reason = DecisionDenyReason.UKLAR_TILGANG_MANGLENDE_INFORMASJON
 		)
+	}
+
+	@Test
+	internal fun `skal gå videre til sjekk av oppfølgingsenhet dersom man får 404 fra norg (geografisk tilknytning)`() {
+		every {
+			adGruppeProvider.hentAdGrupper(navAnsattAzureId)
+		} returns emptyList()
+
+		every {
+			oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)
+		} returns null
+
+		every {
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
+		} throws java.lang.UnsupportedOperationException()
+
+		val decision = policy.evaluate(
+			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(
+				navAnsattAzureId = navAnsattAzureId,
+				norskIdent = norskIdent
+			)
+		)
+		verify(exactly = 1) {
+			oppfolgingsenhetProvider.hentOppfolgingsenhet(any())
+		}
 	}
 
 

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
@@ -11,7 +11,6 @@ import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
 import no.nav.poao_tilgang.core.provider.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.net.http.HttpResponse
 import java.util.UUID
 
 class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
@@ -61,7 +60,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		}
 
 		verify(exactly = 0) {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(any())
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(any())
 		}
 	}
 
@@ -85,7 +84,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		}
 
 		verify(exactly = 0) {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(any())
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(any())
 		}
 	}
 
@@ -100,7 +99,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		} returns ""
 
 		every {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
 		} returns null
 
 		every {
@@ -125,7 +124,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		decision shouldBe Decision.Permit
 
 		verify(exactly = 1) {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(any())
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(any())
 		}
 	}
 
@@ -140,7 +139,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		} returns ""
 
 		every {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
 		} returns "12345"
 
 		every {
@@ -165,7 +164,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		decision shouldBe Decision.Permit
 
 		verify(exactly = 1) {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(any())
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(any())
 		}
 	}
 
@@ -184,7 +183,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		} returns null
 
 		every {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
 		} returns navEnhet
 
 		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(
@@ -219,7 +218,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		} returns null
 
 		every {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
 		} returns null
 
 		val decision = policy.evaluate(
@@ -246,8 +245,8 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 		} returns null
 
 		every {
-			geografiskTilknyttetEnhetProvider.hentGeografiskTilknytetEnhet(norskIdent)
-		} throws java.lang.UnsupportedOperationException()
+			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
+		} returns null
 
 		val decision = policy.evaluate(
 			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(


### PR DESCRIPTION
Forklaring på PR: Vi må forvente at vi ikke finner folk i norg, de kan være døde eller utvandret. I disse tilfellene krasjer vi med runtime-exception mens abac returnerer Deny. Jeg tenker at vi burde håndtere det likt som abac. Vi har allerede en slik håndtering i hentOppfolgingsenhet, hvor vi returnerer null dersom vi ikke finner vedkommende i veilarbarena. Jeg har nå gjort det samme i hentGeografiskEnhet, og dermed også gjort returverdien av den funksjonen nullable. 