### PR TITLE
ABAC må legges i outbound external-policyen siden vi ikke bruker service-discovery

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -79,9 +79,8 @@ spec:
       rules:
         - application: skjermede-personer-pip
           namespace: nom
-        - application: abac-veilarb-proxy
-          namespace: pto
-          cluster: dev-fss
+      external:
+        - host: abac-veilarb-proxy.dev-fss-pub.nais.io
   env:
     - name: MICROSOFT_GRAPH_SCOPE
       value: https://graph.microsoft.com/.default


### PR DESCRIPTION
Kjørte `kubectl apply -f nais-dev.yaml` bare for å teste endringen og nå ser det i alle fall ut som det fungerer.