### PR TITLE
Spesifiser resterende host-er i outbound.external

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -81,6 +81,11 @@ spec:
           namespace: nom
       external:
         - host: abac-veilarb-proxy.dev-fss-pub.nais.io
+        - host: axsys.dev-fss-pub.nais.io
+        - host: veilarbarena.dev-fss-pub.nais.io
+        - host: pdl-api.dev-fss-pub.nais.io
+        - host: norg2.dev-fss-pub.nais.io
+        - host: graph.microsoft.com
   env:
     - name: MICROSOFT_GRAPH_SCOPE
       value: https://graph.microsoft.com/.default

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -81,6 +81,11 @@ spec:
           namespace: nom
       external:
         - host: abac-veilarb-proxy.prod-fss-pub.nais.io
+        - host: axsys.prod-fss-pub.nais.io
+        - host: veilarbarena.prod-fss-pub.nais.io
+        - host: pdl-api.prod-fss-pub.nais.io
+        - host: norg2.prod-fss-pub.nais.io
+        - host: graph.microsoft.com
   env:
     - name: MICROSOFT_GRAPH_SCOPE
       value: https://graph.microsoft.com/.default


### PR DESCRIPTION
En pub-ingress spesifisert = alle pub-ingresser blir tillatt, men tar de med likvel for kompletthet. Ref: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680684572244699?thread_ts=1679409522.527339&cid=C01DE3M9YBV.