### PR TITLE
La til  paw-tilgangskontroll i inboud rules (dev)

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -40,6 +40,9 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: paw-tilgangskontroll
+          namespace: paw
+          cluster: dev-gcp
         - application: paw-arbeidssoker-besvarelse
           namespace: paw
           cluster: dev-gcp


### PR DESCRIPTION
Legger til paw-tilgangskontroll i inboud rules i dev. Dette er en ny komponent fra team PAW som etterhvert vil bli den eneste PAW komponenten som snakker med poao-tilgang.