### PR TITLE
La til paw-tilgangskontroll i inbound rules (prod)

### DIFF
--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -42,6 +42,9 @@ spec:
   accessPolicy:
     inbound:
       rules:
+        - application: paw-tilgangskontroll
+          namespace: paw
+          cluster: prod-gcp
         - application: paw-arbeidssoker-besvarelse
           namespace: paw
           cluster: prod-gcp


### PR DESCRIPTION
La til paw-tilgangskontroll i inbound rules for prod. Dette er er nye tjeneste som etterhvert vil bli den eneste applikasjonen fra PAW som snakker med poao-tilgang.