### PR TITLE
Håndter tilgangsspørringer på gammel ident

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClient.kt
@@ -4,8 +4,25 @@ interface PdlPipClient {
 	fun hentBrukerInfo(brukerIdent: String): BrukerInfo?
 }
 
+enum class IdentGruppe {
+	AKTORID,
+	NPID,
+	FOLKEREGISTERIDENT,
+}
+
+data class Ident(
+	val ident: String,
+	val historisk: Boolean,
+	val gruppe: IdentGruppe
+)
+
+data class Identer(
+	val identer: List<Ident>
+)
+
 data class BrukerInfo(
 	val person: Person,
+	val identer: Identer,
 	val geografiskTilknytning: GeografiskTilknytning?
 )
 

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
@@ -14,10 +14,12 @@ import no.nav.poao_tilgang.api_core_mapper.ApiCoreMapper
 import no.nav.poao_tilgang.application.domain.PolicyEvaluationRequest
 import no.nav.poao_tilgang.application.domain.PolicyEvaluationResult
 import no.nav.poao_tilgang.application.service.AuthService
+import no.nav.poao_tilgang.application.service.GjeldendeIdentService
 import no.nav.poao_tilgang.application.service.PolicyService
 import no.nav.poao_tilgang.application.utils.Issuer
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.PolicyInput
+import no.nav.poao_tilgang.core.domain.PolicyInputWithNorskIdent
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -31,6 +33,7 @@ import java.time.Duration
 class PolicyController(
 	private val authService: AuthService,
 	private val policyService: PolicyService,
+	private val gjeldendeIdentService: GjeldendeIdentService,
 	private val apiCoreMapper: ApiCoreMapper,
 	private val meterRegistry: MeterRegistry
 ) {
@@ -57,8 +60,17 @@ class PolicyController(
 		return EvaluatePoliciesResponse(evaluations)
 	}
 
+
 	private fun evaluateRequest(request: PolicyEvaluationRequestDto<JsonNode>): PolicyEvaluationResultDto {
-		val policyInput = apiCoreMapper.mapToPolicyInput(request.policyId, request.policyInput)
+		val policyInput = apiCoreMapper
+			.mapToPolicyInput(request.policyId, request.policyInput)
+			.let {
+				when (it) {
+					is PolicyInputWithNorskIdent -> byttTilGjeldendeIdent(it)
+					else -> it
+				}
+			}
+
 		val cachedDecision = decisionCache.getIfPresent(policyInput)
 		val result = if (cachedDecision == null) {
 			val evaluation = policyService.evaluatePolicyRequest(PolicyEvaluationRequest(request.requestId, policyInput))
@@ -84,6 +96,11 @@ class PolicyController(
 				reason = decision.reason.name
 			)
 		}
+	}
+
+	private fun byttTilGjeldendeIdent(input: PolicyInputWithNorskIdent): PolicyInputWithNorskIdent {
+		val norskIdent = this.gjeldendeIdentService(input.norskIdent)
+		return input.byttIdent(norskIdent)
 	}
 
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/PolicyController.kt
@@ -100,7 +100,7 @@ class PolicyController(
 
 	private fun byttTilGjeldendeIdent(input: PolicyInputWithNorskIdent): PolicyInputWithNorskIdent {
 		val norskIdent = this.gjeldendeIdentService(input.norskIdent)
-		return input.byttIdent(norskIdent)
+		return input.withIdent(norskIdent)
 	}
 
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
@@ -1,0 +1,23 @@
+package no.nav.poao_tilgang.application.service
+
+import no.nav.poao_tilgang.application.client.pdl_pip.PdlPipClient
+import no.nav.poao_tilgang.core.domain.NorskIdent
+import org.springframework.stereotype.Service
+
+interface GjeldendeIdentProvider: (NorskIdent) -> NorskIdent
+
+@Service
+class GjeldendeIdentService(
+	val pdlpipClient: PdlPipClient
+): GjeldendeIdentProvider {
+
+	/* Gitt en gammel ident typ dnr, bytt det ut med nyeste ident typ fnr og gjør tilgangskontroll mot dette istedet */
+	override fun invoke(ident: NorskIdent): NorskIdent {
+		val brukerInfo = pdlpipClient.hentBrukerInfo(ident)
+		if (brukerInfo == null) return ident
+
+		return brukerInfo.identer.identer
+			.singleOrNull { it.historisk == false }?.ident ?: ident
+	}
+
+}

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
@@ -1,5 +1,6 @@
 package no.nav.poao_tilgang.application.service
 
+import no.nav.poao_tilgang.application.client.pdl_pip.IdentGruppe
 import no.nav.poao_tilgang.application.client.pdl_pip.PdlPipClient
 import no.nav.poao_tilgang.core.domain.NorskIdent
 import org.springframework.stereotype.Service
@@ -17,7 +18,7 @@ class GjeldendeIdentService(
 		if (brukerInfo == null) return ident
 
 		return brukerInfo.identer.identer
-			.singleOrNull { it.historisk == false }?.ident ?: ident
+			.singleOrNull { it.historisk == false && it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident ?: ident
 	}
 
 }

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/IntegrationTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/IntegrationTest.kt
@@ -161,10 +161,17 @@ open class IntegrationTest {
 		return client.newCall(reqBuilder.build()).execute()
 	}
 
-	fun mockPersonData(norskIdent: NorskIdent, brukersEnhet: NavEnhetId, kommuneNr: String = "5000", erSkjermet: Boolean = false) {
+	fun mockPersonData(
+		norskIdent: NorskIdent,
+		brukersEnhet: NavEnhetId,
+		kommuneNr: String = "5000",
+		erSkjermet: Boolean = false,
+		gammelIdent: NorskIdent? = null
+	) {
 		mockPdlPipHttpServer.mockBrukerInfo(
 			norskIdent = norskIdent,
-			gtKommune = kommuneNr
+			gtKommune = kommuneNr,
+			gammelIdent = gammelIdent
 		)
 
 		mockSkjermetPersonHttpServer.mockErSkjermet(

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockPdlPipHttpServer.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockPdlPipHttpServer.kt
@@ -39,6 +39,11 @@ class MockPdlPipHttpServer : MockHttpServer() {
 					  },
 					  "identer": {
 					    "identer": [
+						   {
+					        "ident": "9876543210987",
+					        "historisk": false,
+					        "gruppe": "AKTORID"
+					      },
 					      {
 					        "ident": "${norskIdent}",
 					        "historisk": false,
@@ -48,11 +53,6 @@ class MockPdlPipHttpServer : MockHttpServer() {
 					        "ident": "${gammelIdent ?: 9876543210987}",
 					        "historisk": true,
 					        "gruppe": "FOLKEREGISTERIDENT"
-					      },
-					      {
-					        "ident": "9876543210987",
-					        "historisk": false,
-					        "gruppe": "AKTORID"
 					      }
 					    ]
 					  },

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockPdlPipHttpServer.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/test_util/mock_clients/MockPdlPipHttpServer.kt
@@ -13,7 +13,8 @@ class MockPdlPipHttpServer : MockHttpServer() {
 		gradering: Gradering? = null,
 		gtType: GeografiskTilknytningType = GeografiskTilknytningType.KOMMUNE,
 		gtKommune: String? = null,
-		gtBydel: String? = null
+		gtBydel: String? = null,
+		gammelIdent: String? = null
 	) {
 		val response = MockResponse()
 			.setBody(
@@ -43,6 +44,11 @@ class MockPdlPipHttpServer : MockHttpServer() {
 					        "historisk": false,
 					        "gruppe": "FOLKEREGISTERIDENT"
 					      },
+						  {
+					        "ident": "${gammelIdent ?: 9876543210987}",
+					        "historisk": true,
+					        "gruppe": "FOLKEREGISTERIDENT"
+					      },
 					      {
 					        "ident": "9876543210987",
 					        "historisk": false,
@@ -64,7 +70,7 @@ class MockPdlPipHttpServer : MockHttpServer() {
 		handleRequest(
 			matchPath = "/api/v1/person",
 			matchMethod = "GET",
-			matchHeaders = mapOf("ident" to norskIdent),
+			matchHeaders = mapOf("ident" to (gammelIdent ?: norskIdent)),
 			response = response
 		)
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/PolicyInput.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/PolicyInput.kt
@@ -4,5 +4,6 @@ interface PolicyInput
 
 interface PolicyInputWithNorskIdent : PolicyInput {
 	val norskIdent: NorskIdent
-	fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent
+	/* Copy fra kotlin sin data class er ikke tilgjengelig via interfaces, så lager den eksplisitt */
+	fun withIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent
 }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/PolicyInput.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/PolicyInput.kt
@@ -1,3 +1,8 @@
 package no.nav.poao_tilgang.core.domain
 
 interface PolicyInput
+
+interface PolicyInputWithNorskIdent : PolicyInput {
+	val norskIdent: NorskIdent
+	fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent
+}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilAdressebeskyttetBrukerPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilAdressebeskyttetBrukerPolicy.kt
@@ -9,7 +9,11 @@ interface NavAnsattTilgangTilAdressebeskyttetBrukerPolicy : Policy<NavAnsattTilg
 
 	data class Input (
 		val navAnsattAzureId: AzureObjectId,
-		val norskIdent: NorskIdent
-	) : PolicyInput
+		override val norskIdent: NorskIdent
+	) : PolicyInputWithNorskIdent {
+		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+			return this.copy(norskIdent = norskIdent)
+		}
+	}
 
 }

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilAdressebeskyttetBrukerPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilAdressebeskyttetBrukerPolicy.kt
@@ -11,7 +11,7 @@ interface NavAnsattTilgangTilAdressebeskyttetBrukerPolicy : Policy<NavAnsattTilg
 		val navAnsattAzureId: AzureObjectId,
 		override val norskIdent: NorskIdent
 	) : PolicyInputWithNorskIdent {
-		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+		override fun withIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
 			return this.copy(norskIdent = norskIdent)
 		}
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.kt
@@ -11,8 +11,12 @@ interface NavAnsattTilgangTilEksternBrukerNavEnhetPolicy: Policy<NavAnsattTilgan
 
 	data class Input(
 		val navAnsattAzureId: AzureObjectId,
-		val norskIdent: NorskIdent
-	) : PolicyInput
+		override val norskIdent: NorskIdent
+	) : PolicyInputWithNorskIdent {
+		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+			return this.copy(norskIdent = norskIdent)
+		}
+	}
 
 }
 

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.kt
@@ -13,7 +13,7 @@ interface NavAnsattTilgangTilEksternBrukerNavEnhetPolicy: Policy<NavAnsattTilgan
 		val navAnsattAzureId: AzureObjectId,
 		override val norskIdent: NorskIdent
 	) : PolicyInputWithNorskIdent {
-		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+		override fun withIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
 			return this.copy(norskIdent = norskIdent)
 		}
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
@@ -12,7 +12,7 @@ interface NavAnsattTilgangTilEksternBrukerPolicy : Policy<NavAnsattTilgangTilEks
 		val tilgangType: TilgangType,
 		override val norskIdent: NorskIdent
 	) : PolicyInputWithNorskIdent {
-		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+		override fun withIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
 			return this.copy(norskIdent = norskIdent)
 		}
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/NavAnsattTilgangTilEksternBrukerPolicy.kt
@@ -10,7 +10,11 @@ interface NavAnsattTilgangTilEksternBrukerPolicy : Policy<NavAnsattTilgangTilEks
 	data class Input(
 		val navAnsattAzureId: AzureObjectId,
 		val tilgangType: TilgangType,
-		val norskIdent: NorskIdent
-	) : PolicyInput
+		override val norskIdent: NorskIdent
+	) : PolicyInputWithNorskIdent {
+		override fun byttIdent(norskIdent: NorskIdent): PolicyInputWithNorskIdent {
+			return this.copy(norskIdent = norskIdent)
+		}
+	}
 
 }


### PR DESCRIPTION
Ved evaluering av policy hvor brukers-ident er et parameter byttes `ident: NorskIdent` inn i nyeste ikke-historiske ident av typen `FOLKEREGISTER`. Alle identer hentes allerede fra PIP /person endepunktet i PDL så det går ingen nye kall 