### PR TITLE
Test om en liten sjekk kan løse mulighet for ssrf

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/TilgangController.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/controller/TilgangController.kt
@@ -9,10 +9,12 @@ import no.nav.poao_tilgang.application.service.TilgangService
 import no.nav.poao_tilgang.application.utils.Issuer
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.security.token.support.core.api.ProtectedWithClaims
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 
 @RestController
 @RequestMapping("/api/v1/tilgang")
@@ -25,7 +27,11 @@ class TilgangController(
 	@PostMapping("/modia")
 	fun harTilgangTilModia(@RequestBody request: HarTilgangTilModiaRequest): TilgangResponse {
 		authService.verifyRequestIsMachineToMachine()
+		val regex = "[A-Za-z]\\d{6}".toRegex()
 
+		if (!request.navIdent.matches(regex)) {
+			throw ResponseStatusException(HttpStatus.BAD_REQUEST, "navIdent må ha formatet X123456")
+		}
 		val decision = tilgangService.harTilgangTilModia(request.navIdent)
 
 		return mapTilResponse(decision)

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/controller/TilgangControllerIntegrationTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/controller/TilgangControllerIntegrationTest.kt
@@ -20,21 +20,21 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 401 when not authenticated`() {
-		val response = sendTilgangTilModiaRequest("Z1234")
+		val response = sendTilgangTilModiaRequest("Z123456")
 
 		response.code shouldBe 401
 	}
 
 	@Test
 	fun `harTilgangTilModia - should return 403 when not machine-to-machine request`() {
-		val response = sendTilgangTilModiaRequest("Z1234") { mockOAuthServer.issueAzureAdToken() }
+		val response = sendTilgangTilModiaRequest("Z123456") { mockOAuthServer.issueAzureAdToken() }
 
 		response.code shouldBe 403
 	}
 
 	@Test
 	fun `harTilgangTilModia - should return 'deny' if not member of any ad group`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123716"
 
 		mockAdGrupperResponse(navIdent, emptyList())
 
@@ -49,7 +49,7 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 'deny' if not member of correct ad group`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123716"
 
 		mockAdGrupperResponse(
 			navIdent, listOf(
@@ -68,7 +68,7 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 'permit' if member of modiagenerelltilgang`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123716"
 
 		mockAdGrupperResponse(navIdent, listOf(adGruppeProvider.hentTilgjengeligeAdGrupper().modiaGenerell))
 
@@ -79,7 +79,7 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 'permit' if member of modia-oppfolging`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123716"
 
 		mockAdGrupperResponse(navIdent, listOf(adGruppeProvider.hentTilgjengeligeAdGrupper().modiaOppfolging))
 
@@ -90,7 +90,7 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 'permit' if member of syfo-sensitiv`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123716"
 
 		mockAdGrupperResponse(navIdent, listOf(adGruppeProvider.hentTilgjengeligeAdGrupper().syfoSensitiv))
 
@@ -101,7 +101,7 @@ class TilgangControllerIntegrationTest : IntegrationTest() {
 
 	@Test
 	fun `harTilgangTilModia - should return 'permit' if member of correct role and other`() {
-		val navIdent = "Z12371"
+		val navIdent = "Z123761"
 
 		mockAdGrupperResponse(
 			navIdent, listOf(


### PR DESCRIPTION
Vi har en critical severity alert https://github.com/navikt/poao-tilgang/security/code-scanning/2
Den sier vi har fare for SSRF fordi vi sender brukerinput direkte videre som et parameter til et annet kall.
Måten å fikse dette "korrekt" på er å ha en whitelist å sjekke inputen opp mot, men la inn en sjekk på om at det i alle fall matcher hva en NavIdent ser ut som.