### PR TITLE
Migrer bort fra axsys del 1: Logg diff mellom Axsys og Enhet-spesifikke AD-grupper

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -4,9 +4,9 @@ import io.getunleash.DefaultUnleash
 import io.micrometer.core.annotation.Timed
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
 import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
+import no.nav.poao_tilgang.core.domain.NavEnhetId
 import no.nav.poao_tilgang.core.domain.NavIdent
 import no.nav.poao_tilgang.core.provider.AdGruppeProvider
-import no.nav.poao_tilgang.core.provider.NavEnhetTilgang
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -22,15 +22,20 @@ open class NavEnhetTilgangProviderImpl(
 
 	private val logger = LoggerFactory.getLogger(javaClass)
 
-	@Timed(value = "nav_enhet_tilgang_provider.hent_enhet_tilganger", histogram = true, percentiles = [0.5, 0.95, 0.99], extraTags = ["type", "provider"])
-	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
+	@Timed(
+		value = "nav_enhet_tilgang_provider.hent_enhet_tilganger",
+		histogram = true,
+		percentiles = [0.5, 0.95, 0.99],
+		extraTags = ["type", "provider"]
+	)
+	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetId> {
 		return if (defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF)) {
 			val enhetTilgangerFraADGrupper = hentEnhetTilgangerFraADGrupper(navIdent)
 			val enhetTilgangerFraAxsys = hentEnhetTilgangerFraAxsys(navIdent)
 
 			if (
-				enhetTilgangerFraADGrupper.map { it.enhetId }.sorted() ==
-				enhetTilgangerFraAxsys.map { it.enhetId }.sorted()
+				enhetTilgangerFraADGrupper.sorted() ==
+				enhetTilgangerFraAxsys.sorted()
 			) {
 				logger.info("Enhettilganger er identiske mellom Axsys og AD.")
 			} else {
@@ -53,21 +58,20 @@ open class NavEnhetTilgangProviderImpl(
 	 * @see <a href="https://nav-it.slack.com/archives/CDKEM1HC5/p1746512543818079">Axsys skrus av - end of life 01.10.2025 | Slack - #axsys</a>
 	 * @see <a href="https://nav-ea.public360online.com/locator.aspx?name=Earchive.Document.Details.EArchive&module=Document&subtype=17&recno=1742220">Avvikling av Axsys (001-ADR-IT Axsys) | Public 360 - Arkitekturbeslutninger</a>
 	 */
-	private fun hentEnhetTilgangerFraADGrupper(navIdent: NavIdent): List<NavEnhetTilgang> {
+	private fun hentEnhetTilgangerFraADGrupper(navIdent: NavIdent): List<NavEnhetId> {
 		val navIdentAzureId = adGruppeProvider.hentAzureIdMedNavIdent(navIdent)
 		val adGrupperMedNavn = adGruppeProvider.hentAdGrupper(navIdentAzureId)
 
-		return adGrupperMedNavn.filter { it.navn.startsWith(AD_GRUPPE_ENHET_PREFIKS) }
-			.map { NavEnhetTilgang(it.navn.substringAfter(AD_GRUPPE_ENHET_PREFIKS)) }
+		return adGrupperMedNavn
+			.filter { it.navn.startsWith(AD_GRUPPE_ENHET_PREFIKS) }
+			.map { it.navn.substringAfter(AD_GRUPPE_ENHET_PREFIKS) }
+			.filter { it.length == 4 }
 	}
 
-	private fun hentEnhetTilgangerFraAxsys(navIdent: NavIdent): List<NavEnhetTilgang> =
+	private fun hentEnhetTilgangerFraAxsys(navIdent: NavIdent): List<NavEnhetId> =
 		axsysClient.hentTilganger(navIdent)
-			.map {
-				NavEnhetTilgang(
-					enhetId = it.enhetId
-				)
-			}.also {
+			.map { it.enhetId }
+			.also {
 				//				secureLog.info("Axsys , hentTilganger for navIdent: $navIdent, result: $it")
 			}
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -1,25 +1,71 @@
 package no.nav.poao_tilgang.application.provider
 
+import io.getunleash.DefaultUnleash
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
+import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
 import no.nav.poao_tilgang.core.domain.NavIdent
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgang
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+
+const val AD_GRUPPE_ENHET_PREFIKS = "0000-GA-ENHET_"
 
 @Component
 class NavEnhetTilgangProviderImpl(
-	private val axsysClient: AxsysClient
+	private val axsysClient: AxsysClient,
+	private val adGruppeProvider: AdGruppeProvider,
+	private val defaultUnleash: DefaultUnleash
 ) : NavEnhetTilgangProvider {
 
+	private val logger = LoggerFactory.getLogger(javaClass)
+
 	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
-		return axsysClient.hentTilganger(navIdent)
+		return if (defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF)) {
+			val enhetTilgangerFraADGrupper = hentEnhetTilgangerFraADGrupper(navIdent)
+			val enhetTilgangerFraAxsys = hentEnhetTilgangerFraAxsys(navIdent)
+
+			if (
+				enhetTilgangerFraADGrupper.map { it.enhetId }.sorted() ==
+				enhetTilgangerFraAxsys.map { it.enhetId }.sorted()
+			) {
+				logger.info("Enhettilganger er identiske mellom Axsys og AD.")
+			} else {
+				logger.info("Enhettilganger er ulike mellom Axsys og AD.")
+			}
+
+			enhetTilgangerFraAxsys
+		} else {
+			hentEnhetTilgangerFraAxsys(navIdent)
+		}
+	}
+
+	/**
+	 * 2025-07-07: Tilgang til enhet skal migreres fra Axsys til Entra ID
+	 * og det er laget egne AD-grupper per enhet. Disse bruker et prefiks ([AD_GRUPPE_ENHET_PREFIKS])
+	 * for å kunne skille de fra andre AD-grupper.
+	 *
+	 * Enhetsnummeret må derfor utledes fra AD-gruppens navn.
+	 *
+	 * @see <a href="https://nav-it.slack.com/archives/CDKEM1HC5/p1746512543818079">Axsys skrus av - end of life 01.10.2025 | Slack - #axsys</a>
+	 * @see <a href="https://nav-ea.public360online.com/locator.aspx?name=Earchive.Document.Details.EArchive&module=Document&subtype=17&recno=1742220">Avvikling av Axsys (001-ADR-IT Axsys) | Public 360 - Arkitekturbeslutninger</a>
+	 */
+	private fun hentEnhetTilgangerFraADGrupper(navIdent: NavIdent): List<NavEnhetTilgang> {
+		val navIdentAzureId = adGruppeProvider.hentAzureIdMedNavIdent(navIdent)
+		val adGrupperMedNavn = adGruppeProvider.hentAdGrupper(navIdentAzureId)
+
+		return adGrupperMedNavn.filter { it.navn.startsWith(AD_GRUPPE_ENHET_PREFIKS) }
+			.map { NavEnhetTilgang(it.navn.substringAfter(AD_GRUPPE_ENHET_PREFIKS)) }
+	}
+
+	private fun hentEnhetTilgangerFraAxsys(navIdent: NavIdent): List<NavEnhetTilgang> =
+		axsysClient.hentTilganger(navIdent)
 			.map {
 				NavEnhetTilgang(
 					enhetId = it.enhetId
 				)
 			}.also {
-//				secureLog.info("Axsys , hentTilganger for navIdent: $navIdent, result: $it")
+				//				secureLog.info("Axsys , hentTilganger for navIdent: $navIdent, result: $it")
 			}
-	}
-
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -1,7 +1,6 @@
 package no.nav.poao_tilgang.application.provider
 
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
-import no.nav.poao_tilgang.application.utils.SecureLog.secureLog
 import no.nav.poao_tilgang.core.domain.NavIdent
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgang
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
@@ -16,9 +15,7 @@ class NavEnhetTilgangProviderImpl(
 		return axsysClient.hentTilganger(navIdent)
 			.map {
 				NavEnhetTilgang(
-					enhetId = it.enhetId,
-					enhetNavn = it.enhetNavn,
-					temaer = it.temaer
+					enhetId = it.enhetId
 				)
 			}.also {
 //				secureLog.info("Axsys , hentTilganger for navIdent: $navIdent, result: $it")

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 const val AD_GRUPPE_ENHET_PREFIKS = "0000-GA-ENHET_"
 
 @Component
-class NavEnhetTilgangProviderImpl(
+open class NavEnhetTilgangProviderImpl(
 	private val axsysClient: AxsysClient,
 	private val adGruppeProvider: AdGruppeProvider,
 	private val defaultUnleash: DefaultUnleash

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -1,6 +1,7 @@
 package no.nav.poao_tilgang.application.provider
 
 import io.getunleash.DefaultUnleash
+import io.micrometer.core.annotation.Timed
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
 import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
 import no.nav.poao_tilgang.core.domain.NavIdent
@@ -21,6 +22,7 @@ class NavEnhetTilgangProviderImpl(
 
 	private val logger = LoggerFactory.getLogger(javaClass)
 
+	@Timed(value = "nav_enhet_tilgang_provider.hent_enhet_tilganger", histogram = true, percentiles = [0.5, 0.95, 0.99], extraTags = ["type", "provider"])
 	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
 		return if (defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF)) {
 			val enhetTilgangerFraADGrupper = hentEnhetTilgangerFraADGrupper(navIdent)

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/utils/FeatureToggleUtils.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/utils/FeatureToggleUtils.kt
@@ -1,0 +1,3 @@
+package no.nav.poao_tilgang.application.utils
+
+const val HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF = "poao-tilgang.hent_enhetstilganger_fra_ad_og_logg_diff"

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -69,7 +69,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 	): Decision {
 		val navIdent = adGruppeProvider.hentNavIdentMedAzureId(navAnsattAzureId)
 		val harTilgangTilEnhet = navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-			.any { navEnhetId == it.enhetId }
+			.any { navEnhetId == it }
 		secureLog.info("$name, harTilgangTilEnhet: $harTilgangTilEnhet, navEnhetForBruker: $navEnhetId, navident: $navIdent, azureId: $navAnsattAzureId, for type Enhet: $typeEnhet")
 		return if (harTilgangTilEnhet) Decision.Permit else denyDecisionNotAccessToEnhet
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -19,6 +19,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 	private val navEnhetTilgangProvider: NavEnhetTilgangProvider
 ) : NavAnsattTilgangTilEksternBrukerNavEnhetPolicy {
 
+	private val log = LoggerFactory.getLogger(javaClass)
 	private val secureLog = LoggerFactory.getLogger("SecureLog")
 	private val nasjonalTilgangGrupperOgAdmin = adGruppeProvider.hentTilgjengeligeAdGrupper().let {
 		listOf(

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImpl.kt
@@ -81,7 +81,7 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImpl(
 		}
 
 		val harTilgangTilEnhet = navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-			.any { input.navEnhetId == it.enhetId }
+			.any { input.navEnhetId == it }
 		timer.record("app.poao-tilgang.NavAnsattTilgangTilNavEnhetMedSperre.egen", Duration.ofMillis(System.currentTimeMillis()-startTime))
 
 		return if (harTilgangTilEnhet) Decision.Permit else denyDecision

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImpl.kt
@@ -42,7 +42,7 @@ class NavAnsattTilgangTilNavEnhetPolicyImpl(
 		return if (toggleProvider.brukAbacDecision()) {
 			val harTilgangAbacDesicion = harTilgangAbac(input)
 			if (toggleProvider.logAbacDecisionDiff()) {
-				asyncLogDecisionDiff(name, input, ::harTilgang, { _ ->harTilgangAbacDesicion })
+				asyncLogDecisionDiff(name, input, ::harTilgang, { _ -> harTilgangAbacDesicion })
 			}
 			harTilgangAbacDesicion
 		} else {
@@ -61,7 +61,10 @@ class NavAnsattTilgangTilNavEnhetPolicyImpl(
 
 		val harTilgangAbac = abacProvider.harVeilederTilgangTilNavEnhet(navIdent, input.navEnhetId)
 
-		timer.record("app.poao-tilgang.NavAnsattTilgangTilNavEnhet", Duration.ofMillis(System.currentTimeMillis() - startTime))
+		timer.record(
+			"app.poao-tilgang.NavAnsattTilgangTilNavEnhet",
+			Duration.ofMillis(System.currentTimeMillis() - startTime)
+		)
 
 		return toAbacDecision(harTilgangAbac)
 	}
@@ -70,7 +73,10 @@ class NavAnsattTilgangTilNavEnhetPolicyImpl(
 	internal fun harTilgang(input: NavAnsattTilgangTilNavEnhetPolicy.Input): Decision {
 		val startTime = System.currentTimeMillis()
 		val harTilgangEgen = harTilgangEgen(input)
-		timer.record("app.poao-tilgang.NavAnsattTilgangTilNavEnhet", Duration.ofMillis(System.currentTimeMillis() - startTime))
+		timer.record(
+			"app.poao-tilgang.NavAnsattTilgangTilNavEnhet",
+			Duration.ofMillis(System.currentTimeMillis() - startTime)
+		)
 		return harTilgangEgen
 	}
 
@@ -90,14 +96,15 @@ class NavAnsattTilgangTilNavEnhetPolicyImpl(
 
 		// TODO Slutte med denne sjekken hvis fag er enige (bør ikke trenge tilgang til modia_oppfølging for å ha tilgang til enhet)
 
-		navAnsattTilgangTilOppfolgingPolicy.evaluate(NavAnsattTilgangTilOppfolgingPolicy.Input(input.navAnsattAzureId)).whenDeny {
-			return it
-		}
+		navAnsattTilgangTilOppfolgingPolicy.evaluate(NavAnsattTilgangTilOppfolgingPolicy.Input(input.navAnsattAzureId))
+			.whenDeny {
+				return it
+			}
 
 		val navIdent = adGruppeProvider.hentNavIdentMedAzureId(input.navAnsattAzureId)
 
 		val harTilgangTilEnhet = navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-			.any { input.navEnhetId == it.enhetId }
+			.any { input.navEnhetId == it }
 
 		return if (harTilgangTilEnhet) return Decision.Permit else denyDecision
 	}

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
@@ -4,9 +4,7 @@ import no.nav.poao_tilgang.core.domain.NavEnhetId
 import no.nav.poao_tilgang.core.domain.NavIdent
 
 interface NavEnhetTilgangProvider {
-
 	fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang>
-
 }
 
 data class NavEnhetTilgang(

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
@@ -4,9 +4,5 @@ import no.nav.poao_tilgang.core.domain.NavEnhetId
 import no.nav.poao_tilgang.core.domain.NavIdent
 
 interface NavEnhetTilgangProvider {
-	fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang>
+	fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetId>
 }
-
-data class NavEnhetTilgang(
-	val enhetId: NavEnhetId
-)

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/provider/NavEnhetTilgangProvider.kt
@@ -10,7 +10,5 @@ interface NavEnhetTilgangProvider {
 }
 
 data class NavEnhetTilgang(
-	val enhetId: NavEnhetId,
-	val enhetNavn: String,
-	val temaer: List<String>
+	val enhetId: NavEnhetId
 )

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
@@ -109,9 +109,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 
 		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(
 			NavEnhetTilgang(
-				navEnhet,
-				"",
-				listOf()
+				navEnhet
 			)
 		)
 
@@ -149,9 +147,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 
 		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(
 			NavEnhetTilgang(
-				navEnhet,
-				"",
-				listOf()
+				navEnhet
 			)
 		)
 
@@ -189,9 +185,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 
 		every { navEnhetTilgangProvider.hentEnhetTilganger(navIdent = navIdent) } returns listOf(
 			NavEnhetTilgang(
-				navEnhet,
-				"",
-				listOf()
+				navEnhet
 			)
 		)
 

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
@@ -8,7 +8,10 @@ import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilEksternBrukerNavEnhetPolicy
 import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
-import no.nav.poao_tilgang.core.provider.*
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import no.nav.poao_tilgang.core.provider.GeografiskTilknyttetEnhetProvider
+import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import no.nav.poao_tilgang.core.provider.OppfolgingsenhetProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -107,11 +110,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 			oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)
 		} returns navEnhet
 
-		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(
-			NavEnhetTilgang(
-				navEnhet
-			)
-		)
+		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(navEnhet)
 
 		val decision = policy.evaluate(
 			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(
@@ -145,11 +144,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 			oppfolgingsenhetProvider.hentOppfolgingsenhet(norskIdent)
 		} returns navEnhet
 
-		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(
-			NavEnhetTilgang(
-				navEnhet
-			)
-		)
+		every { navEnhetTilgangProvider.hentEnhetTilganger(any()) } returns listOf(navEnhet)
 
 		val decision = policy.evaluate(
 			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(
@@ -183,11 +178,7 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 			geografiskTilknyttetEnhetProvider.hentGeografiskTilknyttetEnhet(norskIdent)
 		} returns navEnhet
 
-		every { navEnhetTilgangProvider.hentEnhetTilganger(navIdent = navIdent) } returns listOf(
-			NavEnhetTilgang(
-				navEnhet
-			)
-		)
+		every { navEnhetTilgangProvider.hentEnhetTilganger(navIdent = navIdent) } returns listOf(navEnhet)
 
 		val decision = policy.evaluate(
 			NavAnsattTilgangTilEksternBrukerNavEnhetPolicy.Input(

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest.kt
@@ -11,7 +11,7 @@ import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
 import no.nav.poao_tilgang.core.provider.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import java.util.*
 
 class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImplTest {
 

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest.kt
@@ -73,7 +73,7 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns listOf(
-			NavEnhetTilgang(navEnhetId, "test", emptyList())
+			NavEnhetTilgang(navEnhetId)
 		)
 
 		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
@@ -108,7 +108,7 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns listOf(
-			NavEnhetTilgang(navEnhetId, "test", emptyList())
+			NavEnhetTilgang(navEnhetId)
 		)
 		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
 

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest.kt
@@ -6,9 +6,12 @@ import io.mockk.mockk
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilNavEnhetMedSperrePolicy
-import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
 import no.nav.poao_tilgang.core.policy.test_utils.MockTimer
-import no.nav.poao_tilgang.core.provider.*
+import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
+import no.nav.poao_tilgang.core.provider.AbacProvider
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import no.nav.poao_tilgang.core.provider.ToggleProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -48,7 +51,14 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 		} returns navIdent
 
 		oppfolgingPolicy = NavAnsattTilgangTilOppfolgingPolicyImpl(adGruppeProvider)
-		navEnhetMedSperrePolicy = NavAnsattTilgangTilNavEnhetMedSperrePolicyImpl(navEnhetTilgangProvider, adGruppeProvider, abacProvider, mockTimer, toggleProvider, oppfolgingPolicy)
+		navEnhetMedSperrePolicy = NavAnsattTilgangTilNavEnhetMedSperrePolicyImpl(
+			navEnhetTilgangProvider,
+			adGruppeProvider,
+			abacProvider,
+			mockTimer,
+			toggleProvider,
+			oppfolgingPolicy
+		)
 	}
 
 	@Test
@@ -59,7 +69,12 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 			testAdGrupper.aktivitetsplanKvp
 		)
 
-		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision = navEnhetMedSperrePolicy.harTilgang(
+			NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(
+				navAnsattAzureId,
+				navEnhetId
+			)
+		)
 
 		decision shouldBe Decision.Permit
 	}
@@ -72,11 +87,14 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-		} returns listOf(
-			NavEnhetTilgang(navEnhetId)
-		)
+		} returns listOf(navEnhetId)
 
-		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision = navEnhetMedSperrePolicy.harTilgang(
+			NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(
+				navAnsattAzureId,
+				navEnhetId
+			)
+		)
 
 		decision shouldBe Decision.Permit
 	}
@@ -91,7 +109,12 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns emptyList()
 
-		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision = navEnhetMedSperrePolicy.harTilgang(
+			NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(
+				navAnsattAzureId,
+				navEnhetId
+			)
+		)
 
 		decision shouldBe Decision.Deny(
 			"Har ikke tilgang til NAV enhet med sperre",
@@ -107,10 +130,13 @@ class NavAnsattTilgangTilNavEnhetMedSperrePolicyImplTest {
 
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-		} returns listOf(
-			NavEnhetTilgang(navEnhetId)
+		} returns listOf(navEnhetId)
+		val decision = navEnhetMedSperrePolicy.harTilgang(
+			NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(
+				navAnsattAzureId,
+				navEnhetId
+			)
 		)
-		val decision = navEnhetMedSperrePolicy.harTilgang(NavAnsattTilgangTilNavEnhetMedSperrePolicy.Input(navAnsattAzureId, navEnhetId))
 
 		decision shouldBe Decision.Deny(
 			"NAV-ansatt mangler tilgang til AD-gruppen \"0000-GA-Modia-Oppfolging\"",

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImplTest.kt
@@ -73,7 +73,7 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns listOf(
-			NavEnhetTilgang(navEnhetId, "test", emptyList())
+			NavEnhetTilgang(navEnhetId)
 		)
 
 		val decision = tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))

--- a/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImplTest.kt
+++ b/core/src/test/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilNavEnhetPolicyImplTest.kt
@@ -6,9 +6,12 @@ import io.mockk.mockk
 import no.nav.poao_tilgang.core.domain.Decision
 import no.nav.poao_tilgang.core.domain.DecisionDenyReason
 import no.nav.poao_tilgang.core.policy.NavAnsattTilgangTilNavEnhetPolicy
-import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
 import no.nav.poao_tilgang.core.policy.test_utils.MockTimer
-import no.nav.poao_tilgang.core.provider.*
+import no.nav.poao_tilgang.core.policy.test_utils.TestAdGrupper.testAdGrupper
+import no.nav.poao_tilgang.core.provider.AbacProvider
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import no.nav.poao_tilgang.core.provider.ToggleProvider
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
@@ -47,7 +50,14 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 		} returns navIdent
 
 		oppfolgingPolicy = NavAnsattTilgangTilOppfolgingPolicyImpl(adGruppeProvider)
-		tilgangTilNavEnhetPolicy = NavAnsattTilgangTilNavEnhetPolicyImpl(navEnhetTilgangProvider, adGruppeProvider, abacProvider, mockTimer, toggleProvider, oppfolgingPolicy)
+		tilgangTilNavEnhetPolicy = NavAnsattTilgangTilNavEnhetPolicyImpl(
+			navEnhetTilgangProvider,
+			adGruppeProvider,
+			abacProvider,
+			mockTimer,
+			toggleProvider,
+			oppfolgingPolicy
+		)
 	}
 
 	@Test
@@ -59,7 +69,8 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 			testAdGrupper.modiaAdmin
 		)
 
-		val decision = tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision =
+			tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
 
 		decision shouldBe Decision.Permit
 	}
@@ -72,11 +83,10 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 
 		every {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
-		} returns listOf(
-			NavEnhetTilgang(navEnhetId)
-		)
+		} returns listOf(navEnhetId)
 
-		val decision = tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision =
+			tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
 
 		decision shouldBe Decision.Permit
 	}
@@ -91,7 +101,8 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns emptyList()
 
-		val decision = tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision =
+			tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
 
 		decision shouldBe Decision.Deny(
 			"NAV-ansatt mangler tilgang til AD-gruppen \"0000-GA-Modia-Oppfolging\"",
@@ -109,7 +120,8 @@ class NavAnsattTilgangTilNavEnhetPolicyImplTest {
 			navEnhetTilgangProvider.hentEnhetTilganger(navIdent)
 		} returns emptyList()
 
-		val decision = tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
+		val decision =
+			tilgangTilNavEnhetPolicy.harTilgang(NavAnsattTilgangTilNavEnhetPolicy.Input(navAnsattAzureId, navEnhetId))
 
 		decision shouldBe Decision.Deny(
 			"Har ikke tilgang til NAV enhet",

--- a/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Domain.kt
+++ b/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Domain.kt
@@ -90,7 +90,7 @@ class NavAnsatte {
 		val navAnsatt = NavAnsatt()
 		add(navAnsatt)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.modiaOppfolging)
-		navAnsatt.enheter.add(NavEnhetTilgang(enhet, "enhetNavn $enhet", emptyList()))
+		navAnsatt.enheter.add(NavEnhetTilgang(enhet))
 		return navAnsatt
 	}
 
@@ -99,7 +99,7 @@ class NavAnsatte {
 		add(navAnsatt)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.modiaOppfolging)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.gosysNasjonal)
-		navAnsatt.enheter.add(NavEnhetTilgang("0000", "NAV Viken", emptyList()))
+		navAnsatt.enheter.add(NavEnhetTilgang("0000"))
 
 		return navAnsatt
 	}

--- a/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Domain.kt
+++ b/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Domain.kt
@@ -1,11 +1,11 @@
 package no.nav.poao_tilgang.poao_tilgang_test_core
 
 import no.nav.poao_tilgang.core.domain.*
-import no.nav.poao_tilgang.core.provider.NavEnhetTilgang
 import no.nav.poao_tilgang.poao_tilgang_test_core.fnr_generator.FoedselsnummerGenerator
 import java.util.*
 
 internal val fnrGenerator = FoedselsnummerGenerator()
+
 class PrivatBruker(
 	val norskIdent: NorskIdent = fnrGenerator.foedselsnummer().asString,
 	var erSkjermet: Boolean = false,
@@ -17,29 +17,41 @@ class NavAnsatt(
 	val navIdent: NavIdent = nyNavIdent(),
 	val azureObjectId: AzureObjectId = UUID.randomUUID(),
 ) {
-	val enheter: MutableSet<NavEnhetTilgang> = mutableSetOf()
+	val enheter: MutableSet<NavEnhetId> = mutableSetOf()
 	val adGrupper: MutableSet<AdGruppe> = mutableSetOf()
 }
 
 
 val tilgjengligeAdGrupper = AdGrupper(
-	fortroligAdresse = AdGruppe(UUID.fromString("354ad832-93cd-47ca-ba60-cfd6288dfc55"), AdGruppeNavn.FORTROLIG_ADRESSE),
-	strengtFortroligAdresse = AdGruppe(UUID.fromString("660c3c11-b1f7-4e54-93f6-cd4492206fe7"), AdGruppeNavn.STRENGT_FORTROLIG_ADRESSE),
+	fortroligAdresse = AdGruppe(
+		UUID.fromString("354ad832-93cd-47ca-ba60-cfd6288dfc55"),
+		AdGruppeNavn.FORTROLIG_ADRESSE
+	),
+	strengtFortroligAdresse = AdGruppe(
+		UUID.fromString("660c3c11-b1f7-4e54-93f6-cd4492206fe7"),
+		AdGruppeNavn.STRENGT_FORTROLIG_ADRESSE
+	),
 	modiaAdmin = AdGruppe(UUID.fromString("d0cfadfa-8366-4639-b756-a42005bb380f"), AdGruppeNavn.MODIA_ADMIN),
 	modiaOppfolging = AdGruppe(UUID.fromString("ebe5066a-a051-447a-8691-7b4a8b3ac0ae"), AdGruppeNavn.MODIA_OPPFOLGING),
 	modiaGenerell = AdGruppe(UUID.fromString("9f95a39e-6b88-4454-9e8b-a8d2a4f950f0"), AdGruppeNavn.MODIA_GENERELL),
 	gosysNasjonal = AdGruppe(UUID.fromString("017a0c2e-f953-464e-9306-6c7a6d92c82d"), AdGruppeNavn.GOSYS_NASJONAL),
-	gosysUtvidbarTilNasjonal = AdGruppe(UUID.fromString("a837a9b4-4f05-421b-8fb7-1ca35e0302e0"), AdGruppeNavn.GOSYS_UTVIDBAR_TIL_NASJONAL),
+	gosysUtvidbarTilNasjonal = AdGruppe(
+		UUID.fromString("a837a9b4-4f05-421b-8fb7-1ca35e0302e0"),
+		AdGruppeNavn.GOSYS_UTVIDBAR_TIL_NASJONAL
+	),
 	syfoSensitiv = AdGruppe(UUID.fromString("b6318312-a5e3-4e26-ac4c-08f8b86660e8"), AdGruppeNavn.SYFO_SENSITIV),
 	egneAnsatte = AdGruppe(UUID.fromString("e44768ac-e68a-4dd1-b6ad-eebf5eb29924"), AdGruppeNavn.EGNE_ANSATTE),
-	aktivitetsplanKvp = AdGruppe(UUID.fromString("259362c2-f7cd-4de7-b2dd-5a848bfdf61b"), AdGruppeNavn.AKTIVITETSPLAN_KVP)
+	aktivitetsplanKvp = AdGruppe(
+		UUID.fromString("259362c2-f7cd-4de7-b2dd-5a848bfdf61b"),
+		AdGruppeNavn.AKTIVITETSPLAN_KVP
+	)
 )
 
 class PrivatBrukere {
 	private val eksterneBrukere = mutableMapOf<NorskIdent, PrivatBruker>()
 
 	fun add(privatBruker: PrivatBruker) {
-		if(eksterneBrukere.containsKey(privatBruker.norskIdent)){
+		if (eksterneBrukere.containsKey(privatBruker.norskIdent)) {
 			throw IllegalArgumentException("Bruker med norskIdent ${privatBruker.norskIdent} finnes allerede")
 		}
 		eksterneBrukere[privatBruker.norskIdent] = privatBruker
@@ -55,7 +67,7 @@ class PrivatBrukere {
 		return privatBruker
 	}
 
-	fun ny(norskIdent: NorskIdent, ): PrivatBruker {
+	fun ny(norskIdent: NorskIdent): PrivatBruker {
 		val privatBruker = PrivatBruker(norskIdent = norskIdent)
 		add(privatBruker)
 		return privatBruker
@@ -80,17 +92,19 @@ class NavAnsatte {
 	fun get(azureObjectId: AzureObjectId): NavAnsatt? {
 		return navAnsatte[azureObjectId]
 	}
+
 	fun get(navIdent: NavIdent): NavAnsatt? {
 		return navAnsatteMedNavIdent[navIdent]
 	}
 
 	fun nyFor(privatBruker: PrivatBruker): NavAnsatt {
-		val enhet = privatBruker.oppfolgingsenhet ?: throw IllegalArgumentException("EksternBruker må høre til en enhet")
+		val enhet =
+			privatBruker.oppfolgingsenhet ?: throw IllegalArgumentException("EksternBruker må høre til en enhet")
 
 		val navAnsatt = NavAnsatt()
 		add(navAnsatt)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.modiaOppfolging)
-		navAnsatt.enheter.add(NavEnhetTilgang(enhet))
+		navAnsatt.enheter.add(enhet)
 		return navAnsatt
 	}
 
@@ -99,14 +113,15 @@ class NavAnsatte {
 		add(navAnsatt)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.modiaOppfolging)
 		navAnsatt.adGrupper.add(tilgjengligeAdGrupper.gosysNasjonal)
-		navAnsatt.enheter.add(NavEnhetTilgang("0000"))
+		navAnsatt.enheter.add("0000")
 
 		return navAnsatt
 	}
 
 
 }
-class NavContext{
+
+class NavContext {
 	val privatBrukere = PrivatBrukere()
 	val navAnsatt = NavAnsatte()
 

--- a/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
+++ b/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
@@ -4,18 +4,20 @@ import no.nav.poao_tilgang.core.domain.*
 import no.nav.poao_tilgang.core.provider.*
 
 
-
 data class Providers(
 	val navContext: NavContext = NavContext(),
 	val toggleProvider: ToggleProvider = ToggleProviderImpl(),
 	val skjermetPersonProvider: SkjermetPersonProvider = SkjermetPersonProviderImpl(navContext),
 	val oppfolgingsenhetProvider: OppfolgingsenhetProvider = OppfolgingsenhetProviderImpl(navContext),
 	val navEnhetTilgangProvider: NavEnhetTilgangProvider = NavEnhetTilgangProviderImpl(navContext),
-	val geografiskTilknyttetEnhetProvider: GeografiskTilknyttetEnhetProvider = GeografiskTilknyttetEnhetProviderImpl(navContext),
+	val geografiskTilknyttetEnhetProvider: GeografiskTilknyttetEnhetProvider = GeografiskTilknyttetEnhetProviderImpl(
+		navContext
+	),
 	val diskresjonskodeProvider: DiskresjonskodeProvider = DiskresjonskodeProviderImpl(navContext),
 	val adGruppeProvider: AdGruppeProvider = AdGruppeProviderImpl(navContext),
 	val abacProvider: AbacProvider = AbacProviderImpl(),
 )
+
 class ToggleProviderImpl : ToggleProvider {
 	override fun brukAbacDecision(): Boolean {
 		return false
@@ -26,7 +28,7 @@ class ToggleProviderImpl : ToggleProvider {
 	}
 }
 
-class SkjermetPersonProviderImpl(private  val navContext: NavContext) : SkjermetPersonProvider {
+class SkjermetPersonProviderImpl(private val navContext: NavContext) : SkjermetPersonProvider {
 	override fun erSkjermetPerson(norskIdent: String): Boolean {
 		return navContext.privatBrukere.get(norskIdent)?.erSkjermet ?: true
 	}
@@ -42,13 +44,13 @@ class OppfolgingsenhetProviderImpl(private val navContext: NavContext) : Oppfolg
 	}
 }
 
-class NavEnhetTilgangProviderImpl(private val navContext: NavContext): NavEnhetTilgangProvider {
+class NavEnhetTilgangProviderImpl(private val navContext: NavContext) : NavEnhetTilgangProvider {
 	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
 		return navContext.navAnsatt.get(navIdent)?.enheter?.toList() ?: emptyList()
 	}
 }
 
-class GeografiskTilknyttetEnhetProviderImpl(private val navContext: NavContext): GeografiskTilknyttetEnhetProvider {
+class GeografiskTilknyttetEnhetProviderImpl(private val navContext: NavContext) : GeografiskTilknyttetEnhetProvider {
 	override fun hentGeografiskTilknyttetEnhet(norskIdent: NorskIdent): NavEnhetId? {
 		return navContext.privatBrukere.get(norskIdent)?.oppfolgingsenhet //for enklere oppset
 	}
@@ -61,13 +63,13 @@ class GeografiskTilknyttetEnhetProviderImpl(private val navContext: NavContext):
 	}
 }
 
-class DiskresjonskodeProviderImpl(private val  navContext: NavContext): DiskresjonskodeProvider {
+class DiskresjonskodeProviderImpl(private val navContext: NavContext) : DiskresjonskodeProvider {
 	override fun hentDiskresjonskode(norskIdent: String): Diskresjonskode? {
 		return navContext.privatBrukere.get(norskIdent)?.diskresjonskode
 	}
 }
 
-class AdGruppeProviderImpl(private val navContext: NavContext): AdGruppeProvider {
+class AdGruppeProviderImpl(private val navContext: NavContext) : AdGruppeProvider {
 	override fun hentAdGrupper(navAnsattAzureId: AzureObjectId): List<AdGruppe> {
 		return navContext.navAnsatt.get(navAnsattAzureId)?.adGrupper?.toList() ?: emptyList()
 	}
@@ -84,7 +86,8 @@ class AdGruppeProviderImpl(private val navContext: NavContext): AdGruppeProvider
 		return tilgjengligeAdGrupper
 	}
 }
-class AbacProviderImpl(): AbacProvider {
+
+class AbacProviderImpl() : AbacProvider {
 	override fun harVeilederTilgangTilPerson(
 		veilederIdent: String,
 		tilgangType: TilgangType,

--- a/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
+++ b/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
@@ -45,7 +45,7 @@ class OppfolgingsenhetProviderImpl(private val navContext: NavContext) : Oppfolg
 }
 
 class NavEnhetTilgangProviderImpl(private val navContext: NavContext) : NavEnhetTilgangProvider {
-	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
+	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetId> {
 		return navContext.navAnsatt.get(navIdent)?.enheter?.toList() ?: emptyList()
 	}
 }


### PR DESCRIPTION
## Gjer i første omgang sjekk på enhet-spesifikke AD-grupper (`0000-GA-ENHET_*`) parallellt med oppslag mot Axsys, og logger diff-en. Axsys er framleis "fasit". Tanken er å observere ev. diff ein periode før vi kan skru over til å bruke enhet-spesifikk AD-gruppe sjekk som fasit.

Tilpasningen er gjort i `NavEnhetTilgangProviderImpl.hentEnhetTilganger` som per dags dato har avhengigheit til Axsys.

Flyten ved sjekk på enhet-spesifikke AD-grupper er slik:
* hentar `AzureObjectId` til innlogga veileder gitt ved `NavIdent`
  * _til dette brukast eksisterande funksjon `AdGruppeProviderImpl.hentAzureIdMedNavIdent`_
* hentar AD-gruppene til innlogga veileder gitt ved `AzureObjectId` frå førre steg
  * _til dette brukast eksisterande funksjon `AdGruppeProviderImpl.hentAdGrupper`_
* filtrerer AD-gruppene basert på enhet-spesifikt prefisk; `0000-GA-ENHET_*`

Ting som kan vere verdt å merke seg:
* både `AdGruppeProviderImpl.hentAzureIdMedNavIdent` og `AdGruppeProviderImpl.hentAdGrupper` benyttar cache
* dersom `AdGruppeProviderImpl.hentAdGrupper` gir cache-miss vil den først hente `AzureObjectId` for alle AD-grupper for innlogga veiledar og deretter hente `displayName` for AD-grupper som vi ev. ikkje har cached frå før
  * det er endepunkta `v1.0/users/$navAnsattAzureId/getMemberGroups` (for henting av id-ane til AD-gruppene) og `v1.0/directoryObjects/getByIds?$select=id,displayName` (for henting av `displayName` per AD-gruppe id) som nyttast - førstnevnte har ein cap på 10,000 grupper i responsen og sistnevnte har ein cap på 1,000 grupper i requesten så det er teoretisk sett mogleg at ein treffer på desse
* det finnst endepunkt som mellom anna støttar paginering og filtrering på AD-gruppe prefix, til dømes `v1.0/users/$navAnsattAzureId/memberOf` men eg var vald å la være å røre implementasjonen i `AdGruppeProviderImpl` og heller gjenbruke det som eksisterer
  * det har jo vore snakk om at kanskje Tilgangsmaskinen også skal ta over sjekk på oppfølgingsenhet på sikt, så tenkte det var greit å halde scopet minst mogleg dersom det viser seg at populasjonssjekkane i poao-tilgang kan erstattast 1-til-1 med tilgangsmaskinen

---

Endringa er lagt bak ein feature-toggle; dersom togglen er inaktivert så vil vi defaulte tilbake til gamal oppførsel, dvs. kun oppslag mot Axsys, ingen sjekk på enhetspesifikk AD-gruppe og ingen logging av diff. Toggle kan inaktiverast dersom til dømes oppslag mot Microsoft Graph ifm. henting av AD-grupper mot formodning skulle medføre treige responstider.