### PR TITLE
Hent enhettilganger vha. AD-grupper og sammenlign med Axsys, men bruk Axsys som fasit

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -1,18 +1,67 @@
 package no.nav.poao_tilgang.application.provider
 
+import io.getunleash.DefaultUnleash
+import io.micrometer.core.annotation.Timed
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
-import no.nav.poao_tilgang.application.utils.SecureLog.secureLog
+import no.nav.poao_tilgang.application.provider.NavEnhetTilgangProviderImpl.Companion.AD_GRUPPE_ENHET_PREFIKS
+import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
+import no.nav.poao_tilgang.core.domain.AdGruppe
+import no.nav.poao_tilgang.core.domain.NavEnhetId
 import no.nav.poao_tilgang.core.domain.NavIdent
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgang
 import no.nav.poao_tilgang.core.provider.NavEnhetTilgangProvider
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.lang.Integer.parseInt
 
 @Component
-class NavEnhetTilgangProviderImpl(
-	private val axsysClient: AxsysClient
+open class NavEnhetTilgangProviderImpl(
+	private val axsysClient: AxsysClient,
+	private val adGruppeProvider: AdGruppeProvider,
+	private val defaultUnleash: DefaultUnleash
 ) : NavEnhetTilgangProvider {
 
+	private val logger = LoggerFactory.getLogger(javaClass)
+
+	@Timed(
+		value = "nav_enhet_tilgang_provider.hent_enhet_tilganger",
+		histogram = true,
+		percentiles = [0.5, 0.95, 0.99],
+		extraTags = ["type", "provider"]
+	)
 	override fun hentEnhetTilganger(navIdent: NavIdent): List<NavEnhetTilgang> {
+		return if (defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF)) {
+			val enhetTilgangerFraAxsys = hentEnhetTilgangerFraAxsys(navIdent)
+
+			// 2025-07-09: Her sammenlignes og logges bare eventuell differanse mellom gammel (Axsys) og ny
+			// (vha. AD-grupper) måte å hente enhetstilganger på. Axsys er fortsatt "fasit".
+			try {
+				val enhetTilgangerFraADGrupper = hentEnhetTilgangerFraADGrupper(navIdent)
+
+				val unikeEnhetTilgangerFraAxsysSortert =
+					enhetTilgangerFraAxsys.map(NavEnhetTilgang::enhetId).toSortedSet()
+				val unikeEnhetTilgangerFraADGrupperSortert = enhetTilgangerFraADGrupper.toSortedSet()
+
+				if (unikeEnhetTilgangerFraAxsysSortert == unikeEnhetTilgangerFraADGrupperSortert) {
+					logger.info("Enhettilganger er identiske mellom Axsys og AD-grupper.")
+				} else {
+					logger.warn("Enhettilganger er ikke identiske mellom Axsys og AD-grupper.")
+				}
+			} catch (e: NavEnhetIdValideringException) {
+				logger.warn(
+					"Kunne ikke hente enhettilganger fra AD-grupper. Årsak: validering feilet for en eller flere utlede NavEnhetId-er.",
+					e
+				)
+			}
+
+			enhetTilgangerFraAxsys
+		} else {
+			hentEnhetTilgangerFraAxsys(navIdent)
+		}
+	}
+
+	private fun hentEnhetTilgangerFraAxsys(navIdent: NavIdent): List<NavEnhetTilgang> {
 		return axsysClient.hentTilganger(navIdent)
 			.map {
 				NavEnhetTilgang(
@@ -25,4 +74,52 @@ class NavEnhetTilgangProviderImpl(
 			}
 	}
 
+	/**
+	 * 2025-07-09: Tilgang til enhet skal migreres fra Axsys til Entra ID
+	 * og det er laget egne AD-grupper per enhet. Disse bruker et prefiks ([AD_GRUPPE_ENHET_PREFIKS])
+	 * for å kunne skille de fra andre AD-grupper.
+	 *
+	 * Enhetsnummeret må derfor utledes fra AD-gruppens navn.
+	 *
+	 * @see <a href="https://nav-it.slack.com/archives/CDKEM1HC5/p1746512543818079">Axsys skrus av - end of life 01.10.2025 | Slack - #axsys</a>
+	 * @see <a href="https://nav-ea.public360online.com/locator.aspx?name=Earchive.Document.Details.EArchive&module=Document&subtype=17&recno=1742220">Avvikling av Axsys (001-ADR-IT Axsys) | Public 360 - Arkitekturbeslutninger</a>
+	 */
+	private fun hentEnhetTilgangerFraADGrupper(navIdent: NavIdent): List<NavEnhetId> {
+		val navIdentAzureId = adGruppeProvider.hentAzureIdMedNavIdent(navIdent)
+		val adGrupperMedNavn = adGruppeProvider.hentAdGrupper(navIdentAzureId)
+
+		return adGrupperMedNavn
+			.map(AdGruppe::navn)
+			.filter { it.startsWith(AD_GRUPPE_ENHET_PREFIKS) }
+			.map(::tilNavEnhetId)
+	}
+
+	companion object {
+		private const val AD_GRUPPE_ENHET_PREFIKS = "0000-GA-ENHET_"
+		private const val NAV_ENHET_ID_LENGDE = 4
+
+		fun tilNavEnhetId(adGruppeNavn: String): NavEnhetId {
+			return adGruppeNavn
+				.uppercase()
+				.substringAfter(AD_GRUPPE_ENHET_PREFIKS)
+				.let(::tilValidertNavEnhetId)
+		}
+
+		private fun tilValidertNavEnhetId(navEnhetId: String): NavEnhetId {
+			if (navEnhetId.length != NAV_ENHET_ID_LENGDE) throw NavEnhetIdValideringException("Ugyldig lengde: ${navEnhetId.length}. Forventet: $NAV_ENHET_ID_LENGDE.")
+			if (
+				try {
+					parseInt(navEnhetId)
+					false
+				} catch (_: NumberFormatException) {
+					true
+				}
+			) throw NavEnhetIdValideringException("Ugyldige tegn: ${navEnhetId.length}. Forventet: 4 siffer.")
+
+			return navEnhetId
+		}
+	}
+
+	internal data class NavEnhetIdValideringException(val melding: String) : RuntimeException(melding)
 }
+

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImpl.kt
@@ -3,7 +3,6 @@ package no.nav.poao_tilgang.application.provider
 import io.getunleash.DefaultUnleash
 import io.micrometer.core.annotation.Timed
 import no.nav.poao_tilgang.application.client.axsys.AxsysClient
-import no.nav.poao_tilgang.application.provider.NavEnhetTilgangProviderImpl.Companion.AD_GRUPPE_ENHET_PREFIKS
 import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
 import no.nav.poao_tilgang.core.domain.AdGruppe
 import no.nav.poao_tilgang.core.domain.NavEnhetId

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/utils/FeatureToggleUtils.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/utils/FeatureToggleUtils.kt
@@ -1,0 +1,3 @@
+package no.nav.poao_tilgang.application.utils
+
+const val HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF = "poao-tilgang.hent_enhetstilganger_fra_ad_og_logg_diff"

--- a/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImplTest.kt
+++ b/application/src/test/kotlin/no/nav/poao_tilgang/application/provider/NavEnhetTilgangProviderImplTest.kt
@@ -1,0 +1,78 @@
+package no.nav.poao_tilgang.application.provider
+
+import io.getunleash.DefaultUnleash
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.common.types.identer.NavIdent
+import no.nav.poao_tilgang.application.client.axsys.AxsysClient
+import no.nav.poao_tilgang.application.utils.HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF
+import no.nav.poao_tilgang.core.provider.AdGruppeProvider
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.*
+
+class NavEnhetTilgangProviderImplTest {
+
+	@Test
+	fun `skal sammenligne enhettilganger`() {
+		val axsysClient = mockk<AxsysClient>(relaxed = true)
+		val adGruppeProvider = mockk<AdGruppeProvider>(relaxed = true)
+		val defaultUnleash = mockk<DefaultUnleash>(relaxed = true)
+		every { defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF) } returns true
+		every { adGruppeProvider.hentAzureIdMedNavIdent("Z999999") } returns UUID.fromString("13c9c66f-8381-4d17-b2b4-625401f26083")
+		val navEnhetTilgangProvider = NavEnhetTilgangProviderImpl(axsysClient, adGruppeProvider, defaultUnleash)
+
+		navEnhetTilgangProvider.hentEnhetTilganger(NavIdent.of("Z999999").toString())
+
+		verify(exactly = 1) { axsysClient.hentTilganger("Z999999") }
+		verify(exactly = 1) { adGruppeProvider.hentAzureIdMedNavIdent("Z999999") }
+		verify(exactly = 1) { adGruppeProvider.hentAdGrupper(UUID.fromString("13c9c66f-8381-4d17-b2b4-625401f26083")) }
+	}
+
+	@Test
+	fun `skal ikke sammenligne enhettilganger`() {
+		val axsysClient = mockk<AxsysClient>(relaxed = true)
+		val adGruppeProvider = mockk<AdGruppeProvider>(relaxed = true)
+		val defaultUnleash = mockk<DefaultUnleash>(relaxed = true)
+		every { defaultUnleash.isEnabled(HENT_ENHETSTILGANGER_FRA_AD_OG_LOGG_DIFF) } returns false
+		val navEnhetTilgangProvider = NavEnhetTilgangProviderImpl(axsysClient, adGruppeProvider, defaultUnleash)
+
+		navEnhetTilgangProvider.hentEnhetTilganger(NavIdent.of("Z999999").toString())
+
+		verify(exactly = 1) { axsysClient.hentTilganger("Z999999") }
+		verify { adGruppeProvider wasNot Called }
+	}
+
+	@ParameterizedTest
+	@ValueSource(
+		strings = [
+			"0000-GA-ENHET_1234",
+			"0000-ga-enhet_1234"
+		]
+	)
+	fun `skal returnere validert NavEnhetId`(gyldigAdGruppe: String) {
+		val validertNavEnhetId = NavEnhetTilgangProviderImpl.tilNavEnhetId(gyldigAdGruppe)
+		assertEquals("1234", validertNavEnhetId)
+	}
+
+	@ParameterizedTest
+	@ValueSource(
+		strings = [
+			"0000-GA-ENHET_ABCD",
+			"1234-GA-ENHET_1234",
+			"0000-GA-ENHET_12345"
+		]
+	)
+	fun `skal feile validering`(ugyldigAdGruppe: String) {
+		assertThrows<NavEnhetTilgangProviderImpl.NavEnhetIdValideringException> {
+			NavEnhetTilgangProviderImpl.tilNavEnhetId(
+				ugyldigAdGruppe
+			)
+		}
+	}
+}


### PR DESCRIPTION
## Gjer i første omgang sjekk på enhet-spesifikke AD-grupper (`0000-GA-ENHET_*`) parallellt med oppslag mot Axsys, og logger diff-en. Axsys er framleis "fasit". Tanken er å observere ev. diff ein periode før vi kan skru over til å bruke enhet-spesifikk AD-gruppe sjekk som fasit.

Tilpasningen er gjort i `NavEnhetTilgangProviderImpl.hentEnhetTilganger` som per dags dato er den modulen som har avhengigheit til Axsys.

Flyten ved sjekk på enhet-spesifikke AD-grupper er slik:
* hentar `AzureObjectId` til innlogga veileder gitt ved `NavIdent`
  * _til dette brukast eksisterande funksjon `AdGruppeProviderImpl.hentAzureIdMedNavIdent`_
* hentar AD-gruppene til innlogga veileder gitt ved `AzureObjectId` frå førre steg
  * _til dette brukast eksisterande funksjon `AdGruppeProviderImpl.hentAdGrupper`_
* filtrerer AD-gruppene basert på enhet-spesifikt prefisk; `0000-GA-ENHET_*`

Ting som kan vere verdt å merke seg:
* både `AdGruppeProviderImpl.hentAzureIdMedNavIdent` og `AdGruppeProviderImpl.hentAdGrupper` benyttar cache
* dersom `AdGruppeProviderImpl.hentAdGrupper` gir cache-miss vil den først hente `AzureObjectId` for alle AD-grupper for innlogga veiledar og deretter hente `displayName` for AD-grupper som vi ev. ikkje har cached frå før
  * det er endepunkta `v1.0/users/$navAnsattAzureId/getMemberGroups` (for henting av id-ane til AD-gruppene) og `v1.0/directoryObjects/getByIds?$select=id,displayName` (for henting av `displayName` per AD-gruppe id) som nyttast - førstnevnte har ein cap på 10,000 grupper i responsen og sistnevnte har ein cap på 1,000 grupper i requesten så det er teoretisk sett mogleg at ein treffer på desse
* det finnst endepunkt som mellom anna støttar paginering og filtrering på AD-gruppe prefix, til dømes `v1.0/users/$navAnsattAzureId/memberOf` men eg var vald å la være å røre implementasjonen i `AdGruppeProviderImpl` og heller gjenbruke det som eksisterer
  * det har jo vore snakk om at kanskje Tilgangsmaskinen også skal ta over sjekk på oppfølgingsenhet på sikt, så tenkte det var greit å halde scopet minst mogleg dersom det viser seg at populasjonssjekkane i poao-tilgang kan erstattast 1-til-1 med tilgangsmaskinen

---

Endringa er lagt bak ein feature-toggle; dersom togglen er inaktivert så vil vi defaulte tilbake til gamal oppførsel, dvs. kun oppslag mot Axsys, ingen sjekk på enhetspesifikk AD-gruppe og ingen logging av diff. Toggle kan inaktiverast dersom til dømes oppslag mot Microsoft Graph ifm. henting av AD-grupper mot formodning skulle medføre treige responstider.