### PR TITLE
Endret navn til applikasjonen paw-arbeidssoekerregisteret-api-oppslag

### DIFF
--- a/.nais/nais-dev.yaml
+++ b/.nais/nais-dev.yaml
@@ -57,7 +57,7 @@ spec:
         - application: paw-arbeidssokerregisteret-api-soek
           namespace: paw
           cluster: dev-gcp
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
           cluster: dev-gcp
         - application: paw-arbeidssokerregisteret-api-inngang

--- a/.nais/nais-prod.yaml
+++ b/.nais/nais-prod.yaml
@@ -102,7 +102,7 @@ spec:
         - application: paw-arbeidssokerregisteret-api-soek
           namespace: paw
           cluster: prod-gcp
-        - application: paw-arbeidssoekerregisteret-api-oppslag
+        - application: paw-arbeidssoekerregisteret-api-oppslag-v2
           namespace: paw
           cluster: prod-gcp
         - application: paw-arbeidssokerregisteret-api-inngang


### PR DESCRIPTION
følgende tjeneste vil etterhvert fases ut:
ingress: https://oppslag-arbeidssoekerregisteret.intern.nav.no/
service discovery: paw-arbeidssoekerregisteret-api-oppslag
Erstatning er alt klar i dev og prod. Den er tilgjengelig via service discovery: paw-arbeidssoekerregisteret-api-oppslag-v2

https://trello.com/c/XncmtMMv/1090-endre-paw-arbeidssokerregister-til-v2