### PR TITLE
Kaster exception på feil 404 ved henting av brukerinfo fra pdl

### DIFF
--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/CachedPdlpipClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/CachedPdlpipClient.kt
@@ -1,7 +1,7 @@
 package no.nav.poao_tilgang.application.client.pdl_pip
 
 import com.github.benmanes.caffeine.cache.Caffeine
-import no.nav.poao_tilgang.application.utils.CacheUtils.tryCacheFirstNullable
+import no.nav.poao_tilgang.application.utils.CacheUtils.tryCacheFirstNotNull
 import no.nav.poao_tilgang.core.domain.NorskIdent
 import java.time.Duration
 
@@ -13,8 +13,8 @@ class CachedPdlpipClient(
 		.expireAfterWrite(Duration.ofHours(1))
 		.build<NorskIdent, BrukerInfo>()
 
-	override fun hentBrukerInfo(brukerIdent: String): BrukerInfo? {
-		return tryCacheFirstNullable(norskIdentToBrukerInfoCache, brukerIdent) {
+	override fun hentBrukerInfo(brukerIdent: String): BrukerInfo {
+		return tryCacheFirstNotNull(norskIdentToBrukerInfoCache, brukerIdent) {
 			pdlPipClient.hentBrukerInfo(brukerIdent)
 		}
 	}

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClient.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClient.kt
@@ -1,7 +1,7 @@
 package no.nav.poao_tilgang.application.client.pdl_pip
 
 interface PdlPipClient {
-	fun hentBrukerInfo(brukerIdent: String): BrukerInfo?
+	fun hentBrukerInfo(brukerIdent: String): BrukerInfo
 }
 
 enum class IdentGruppe {

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClientImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClientImpl.kt
@@ -27,7 +27,7 @@ open class PdlPipClientImpl(
 	)
 	override fun hentBrukerInfo(
 		brukerIdent: NorskIdent,
-	): BrukerInfo? {
+	): BrukerInfo {
 		val secureLog = LoggerFactory.getLogger("SecureLog")
 
 		val request = Request.Builder()
@@ -39,7 +39,7 @@ open class PdlPipClientImpl(
 
 		httpClient.newCall(request).execute().use { response ->
 			if (response.code == 404) {
-				secureLog.warn("Fant ikke bruker med brukerIdent $brukerIdent i PDL");
+				secureLog.warn("Fant ikke bruker med brukerIdent $brukerIdent i PDL")
 				throw BrukerFinnesIkkeException("Bruker finnes ikke i pdl. Status: ${response.code}")
 			}
 			if (!response.isSuccessful) {

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClientImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/client/pdl_pip/PdlPipClientImpl.kt
@@ -3,9 +3,11 @@ package no.nav.poao_tilgang.application.client.pdl_pip
 import io.micrometer.core.annotation.Timed
 import no.nav.common.rest.client.RestClient
 import no.nav.poao_tilgang.application.utils.JsonUtils.fromJsonString
+import no.nav.poao_tilgang.core.domain.BrukerFinnesIkkeException
 import no.nav.poao_tilgang.core.domain.NorskIdent
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 
@@ -26,6 +28,7 @@ open class PdlPipClientImpl(
 	override fun hentBrukerInfo(
 		brukerIdent: NorskIdent,
 	): BrukerInfo? {
+		val secureLog = LoggerFactory.getLogger("SecureLog")
 
 		val request = Request.Builder()
 			.url("$baseUrl/api/v1/person")
@@ -36,7 +39,8 @@ open class PdlPipClientImpl(
 
 		httpClient.newCall(request).execute().use { response ->
 			if (response.code == 404) {
-				return null
+				secureLog.warn("Fant ikke bruker med brukerIdent $brukerIdent i PDL");
+				throw BrukerFinnesIkkeException("Bruker finnes ikke i pdl. Status: ${response.code}")
 			}
 			if (!response.isSuccessful) {
 				throw RuntimeException("Klarte ikke å hente personinfo fra pdl-pip. Status: ${response.code}")

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/middleware/ControllerAdvice.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/middleware/ControllerAdvice.kt
@@ -2,6 +2,7 @@ package no.nav.poao_tilgang.application.middleware
 
 
 import no.nav.poao_tilgang.core.domain.PolicyNotImplementedException
+import no.nav.poao_tilgang.core.domain.BrukerFinnesIkkeException
 import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -21,6 +22,15 @@ open class ControllerAdvice {
 		return ResponseEntity
 			.status(HttpStatus.BAD_REQUEST)
 			.body(HttpStatus.BAD_REQUEST.reasonPhrase)
+	}
+
+	@ExceptionHandler(BrukerFinnesIkkeException::class)
+	fun handleBrukerFinnesIkkeException(e: BrukerFinnesIkkeException): ResponseEntity<String> {
+		log.error(e.message, e)
+
+		return ResponseEntity
+			.status(HttpStatus.NOT_FOUND)
+			.body(HttpStatus.NOT_FOUND.reasonPhrase)
 	}
 
 	@ExceptionHandler(JwtTokenUnauthorizedException::class)

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/DiskresjonskodeProviderImpl.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/provider/DiskresjonskodeProviderImpl.kt
@@ -14,8 +14,8 @@ class DiskresjonskodeProviderImpl(
 
 	override fun hentDiskresjonskode(norskIdent: String): Diskresjonskode? {
 		return pdlPipClient.hentBrukerInfo(norskIdent)
-			?.person
-			?.adressebeskyttelse?.firstOrNull()?.let { it.tilDiskresjonskode() }
+			.person
+			.adressebeskyttelse?.firstOrNull()?.let { it.tilDiskresjonskode() }
 			.also {
 //				secureLog.info("PdlPip , hentDiskresjonskode for fnr: $norskIdent, result: $it")
 			}

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
@@ -15,10 +15,9 @@ class GjeldendeIdentService(
 	/* Gitt en gammel ident typ dnr, bytt det ut med nyeste ident typ fnr og gjør tilgangskontroll mot dette istedet */
 	override fun invoke(ident: NorskIdent): NorskIdent {
 		val brukerInfo = pdlpipClient.hentBrukerInfo(ident)
-		if (brukerInfo == null) return ident
 
-		return brukerInfo.identer.identer
-			.singleOrNull { it.historisk == false && it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident ?: ident
+		return brukerInfo?.identer?.identer
+			?.singleOrNull { it.historisk == false && it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident ?: ident
 	}
 
 }

--- a/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
+++ b/application/src/main/kotlin/no/nav/poao_tilgang/application/service/GjeldendeIdentService.kt
@@ -2,6 +2,7 @@ package no.nav.poao_tilgang.application.service
 
 import no.nav.poao_tilgang.application.client.pdl_pip.IdentGruppe
 import no.nav.poao_tilgang.application.client.pdl_pip.PdlPipClient
+import no.nav.poao_tilgang.core.domain.BrukerFinnesIkkeException
 import no.nav.poao_tilgang.core.domain.NorskIdent
 import org.springframework.stereotype.Service
 
@@ -16,8 +17,9 @@ class GjeldendeIdentService(
 	override fun invoke(ident: NorskIdent): NorskIdent {
 		val brukerInfo = pdlpipClient.hentBrukerInfo(ident)
 
-		return brukerInfo?.identer?.identer
-			?.singleOrNull { it.historisk == false && it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }?.ident ?: ident
+		return brukerInfo.identer.identer
+			.singleOrNull { it.historisk == false && it.gruppe == IdentGruppe.FOLKEREGISTERIDENT }
+			?.ident ?: throw BrukerFinnesIkkeException("Fant ikke gjeldende ident for bruker.")
 	}
 
 }

--- a/client/src/main/kotlin/no/nav/poao_tilgang/client/PoaoTilgangHttpClient.kt
+++ b/client/src/main/kotlin/no/nav/poao_tilgang/client/PoaoTilgangHttpClient.kt
@@ -149,7 +149,6 @@ fun toRequestDto(policyRequest: PolicyRequest): PolicyEvaluationRequestDto<Any> 
 			policyInput = NavAnsattNavIdentSkrivetilgangTilEksternBrukerPolicyInputV1Dto(
 				navIdent = policyRequest.policyInput.navIdent,
 				norskIdent = policyRequest.policyInput.norskIdent,
-
 				),
 			policyId = PolicyId.NAV_ANSATT_NAV_IDENT_SKRIVETILGANG_TIL_EKSTERN_BRUKER_V1
 		)

--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/BrukerFinnesIkkeException.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/domain/BrukerFinnesIkkeException.kt
@@ -1,0 +1,3 @@
+package no.nav.poao_tilgang.core.domain
+
+class BrukerFinnesIkkeException(msg: String) : Exception(msg)


### PR DESCRIPTION
Denne Pren handler om å håndtere 404 feil ved henting av brukerinfo fra pdl. Før utførte vi tilgang sjekken av veileder selv om bruker fantes ikke i pdl. I denne PRen kaster vi exception BrukerFinnesIkkeException (NOT_FOUND) og logger varsel med brukerident i securelogs om pdl returnerer 404 i responsen.