### PR TITLE
bruker navcontext for tilgangsmaskinprovider for tester

### DIFF
--- a/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
+++ b/poao-tilgang-test-core/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/Providers.kt
@@ -78,6 +78,37 @@ class AdGruppeProviderImpl(private val navContext: NavContext) : AdGruppeProvide
 
 class TilgangmaskinProviderImpl(private val navContext: NavContext) : TilgangmaskinProvider {
 	override fun evaluerKompletteRegler(norskIdent: String, navIdent: NavIdent): Decision {
-		return Decision.Permit
+		val navAnsatt = navContext.navAnsatt.get(navIdent) ?: throw IllegalArgumentException("NavAnsatt med navIdent $navIdent finnes ikke")
+		val privatBruker = navContext.privatBrukere.get(norskIdent) ?: throw IllegalArgumentException("PrivatBruker med norskIdent $norskIdent finnes ikke")
+
+		if (privatBruker.diskresjonskode != null) {
+			if (privatBruker.diskresjonskode == Diskresjonskode.STRENGT_FORTROLIG_UTLAND) {
+				if (navAnsatt.adGrupper.none { it == tilgjengligeAdGrupper.strengtFortroligAdresse }) {
+					return Decision.Deny("Veileder har ikke tilgang til bruker med strengt fortrolig utland", DecisionDenyReason.IKKE_TILGANG_TIL_STRENGT_FORTROLIG_UTLAND_BRUKER)
+				}
+			}
+			if (privatBruker.diskresjonskode == Diskresjonskode.STRENGT_FORTROLIG) {
+				if (navAnsatt.adGrupper.none { it == tilgjengligeAdGrupper.strengtFortroligAdresse }) {
+					return Decision.Deny("Veileder har ikke tilgang til bruker med strengt fortrolig adresse", DecisionDenyReason.IKKE_TILGANG_TIL_STRENGT_FORTROLIG_BRUKER)
+				}
+			}
+			if (privatBruker.diskresjonskode == Diskresjonskode.FORTROLIG) {
+				if (navAnsatt.adGrupper.none { it == tilgjengligeAdGrupper.fortroligAdresse }) {
+					return Decision.Deny("Veileder har ikke tilgang til bruker med fortrolig adresse", DecisionDenyReason.IKKE_TILGANG_TIL_FORTROLIG_BRUKER)
+				}
+			}
+		}
+
+		if (privatBruker.erSkjermet && navAnsatt.adGrupper.none { it == tilgjengligeAdGrupper.egneAnsatte }) {
+			return Decision.Deny("Veileder har ikke tilgang til skjermet person", DecisionDenyReason.IKKE_TILGANG_TIL_SKJERMET_PERSON)
+		}
+
+		return if (navAnsatt.adGrupper.any { it == tilgjengligeAdGrupper.gosysNasjonal }) {
+			Decision.Permit
+		} else if (navAnsatt.enheter.any { it.enhetId == privatBruker.oppfolgingsenhet }) {
+			Decision.Permit
+		} else {
+			Decision.Deny("Veileder har ikke tilgang til brukers enhet", DecisionDenyReason.IKKE_TILGANG_TIL_NAV_ENHET)
+		}
 	}
 }

--- a/poao-tilgang-test-core/src/test/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/NavContextTest.kt
+++ b/poao-tilgang-test-core/src/test/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/NavContextTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 class NavContextTest {
 	val navContext = NavContext()
 	val providers = Policies(navContext)
-	val polecyResolver = providers.policyResolver
+	val policyResolver = providers.policyResolver
 
 	@Test
 	fun `veileder skal ha tilgang til bruker`() {
@@ -22,7 +22,7 @@ class NavContextTest {
 			norskIdent = nyEksternBruker.norskIdent
 		)
 
-		val result = polecyResolver.evaluate(input)
+		val result = policyResolver.evaluate(input)
 
 		result.decision shouldBe Decision.Permit
 	}
@@ -38,7 +38,7 @@ class NavContextTest {
 			norskIdent = nyEksternBruker.norskIdent
 		)
 
-		val result = polecyResolver.evaluate(input)
+		val result = policyResolver.evaluate(input)
 
 		result.decision shouldBe Decision.Permit
 	}
@@ -54,9 +54,31 @@ class NavContextTest {
 			norskIdent = nyEksternBruker.norskIdent
 		)
 
-		val result = polecyResolver.evaluate(input)
+		val result = policyResolver.evaluate(input)
 
 		result.decision shouldBe Decision.Permit
 	}
 
+	@Test
+	fun `tilgangsmaskinprodvider - brukers veileder skal ha tilgang til bruker`() {
+		val nyEksternBruker = navContext.privatBrukere.ny()
+		val veileder = navContext.navAnsatt.nyFor(nyEksternBruker)
+		val tilgangsmaskinProvider = TilgangmaskinProviderImpl(navContext)
+
+		val result = tilgangsmaskinProvider.evaluerKompletteRegler(nyEksternBruker.norskIdent, veileder.navIdent)
+
+		result.isPermit shouldBe true
+	}
+
+	@Test
+	fun `tilgangsmaskinprodvider - annen veileder har ikke tilgang til bruker`() {
+		val nyEksternBruker = navContext.privatBrukere.ny()
+		val annenEksternBruker = navContext.privatBrukere.ny()
+		val veileder = navContext.navAnsatt.nyFor(annenEksternBruker)
+		val tilgangsmaskinProvider = TilgangmaskinProviderImpl(navContext)
+
+		val result = tilgangsmaskinProvider.evaluerKompletteRegler(nyEksternBruker.norskIdent, veileder.navIdent)
+
+		result.isDeny shouldBe true
+	}
 }


### PR DESCRIPTION
Lager en forenklet versjon av tilgangsmaskin-logikken for tester som bruker nav-contexten i stedet for at den kun returnerer permit. 