### PR TITLE
Rettet pakkenavn (package name) til TilgangMockClient

### DIFF
--- a/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
+++ b/core/src/main/kotlin/no/nav/poao_tilgang/core/policy/impl/NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl.kt
@@ -56,8 +56,8 @@ class NavAnsattTilgangTilEksternBrukerNavEnhetPolicyImpl(
 			harTilgangTilEnhetForBruker(navAnsattAzureId, navEnhetId, "oppfolgingsEnhet")
 				.whenPermit { return it }
 		}
-		if (gtEnhet == null && oppfolgingsEnhet == null) return denyDecisionEksternbrukerMissingEnhet
-		else return denyDecisionNotAccessToEnhet
+		return if (gtEnhet == null && oppfolgingsEnhet == null) denyDecisionEksternbrukerMissingEnhet
+		else denyDecisionNotAccessToEnhet
 	}
 
 	fun harTilgangTilEnhetForBruker(

--- a/poao-tilgang-test-mockclient/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/PoaoTilgangMockClient.kt
+++ b/poao-tilgang-test-mockclient/src/main/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/PoaoTilgangMockClient.kt
@@ -1,14 +1,20 @@
-package no.nav.poao_tilgang.client
+package no.nav.poao_tilgang.poao_tilgang_test_core
 
 import tools.jackson.databind.JsonNode
 import no.nav.poao_tilgang.api.dto.response.Diskresjonskode
 import no.nav.poao_tilgang.api.dto.response.TilgangsattributterResponse
 import no.nav.poao_tilgang.api_core_mapper.ApiCoreMapper
 import no.nav.poao_tilgang.api_core_mapper.PoaoTilgangObjectMapper
+import no.nav.poao_tilgang.client.AdGruppe
+import no.nav.poao_tilgang.client.Decision
+import no.nav.poao_tilgang.client.NorskIdent
+import no.nav.poao_tilgang.client.PoaoTilgangClient
+import no.nav.poao_tilgang.client.PolicyInput
+import no.nav.poao_tilgang.client.PolicyRequest
+import no.nav.poao_tilgang.client.PolicyResult
 import no.nav.poao_tilgang.client.api.ApiResult
 import no.nav.poao_tilgang.client.api.ResponseDataApiException
-import no.nav.poao_tilgang.poao_tilgang_test_core.NavContext
-import no.nav.poao_tilgang.poao_tilgang_test_core.Policies
+import no.nav.poao_tilgang.client.toRequestDto
 import java.util.*
 
 class PoaoTilgangMockClient(val navContext: NavContext = NavContext()): PoaoTilgangClient {
@@ -39,8 +45,7 @@ class PoaoTilgangMockClient(val navContext: NavContext = NavContext()): PoaoTilg
 		val valueToTree = PoaoTilgangObjectMapper.objectMapper.valueToTree<JsonNode>(requestDto.policyInput)
 		val policyInput = apiCoreMapper.mapToPolicyInput(requestDto.policyId, valueToTree)
 		val result = resolver.evaluate(policyInput)
-		val decision = result.decision
-		return when(decision) {
+		return when(val decision = result.decision) {
 			is no.nav.poao_tilgang.core.domain.Decision.Permit -> Decision.Permit
 			is no.nav.poao_tilgang.core.domain.Decision.Deny -> Decision.Deny(decision.message, decision.reason.name)
 		}

--- a/poao-tilgang-test-mockclient/src/test/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/PoaoTilgangMockClientTest.kt
+++ b/poao-tilgang-test-mockclient/src/test/kotlin/no/nav/poao_tilgang/poao_tilgang_test_core/PoaoTilgangMockClientTest.kt
@@ -2,7 +2,6 @@ package no.nav.poao_tilgang.poao_tilgang_test_core
 
 import io.kotest.matchers.shouldBe
 import no.nav.poao_tilgang.client.NavAnsattTilgangTilEksternBrukerPolicyInput
-import no.nav.poao_tilgang.client.PoaoTilgangMockClient
 import no.nav.poao_tilgang.client.TilgangType
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
TilgangMockClient lå i feil pakke. Filplasseringen for TilgangMockClient.kt samsvarte ikke med den definerte pakken. Denne PR-en retter opp dette ved å flytte filen til riktig package-struktur.